### PR TITLE
tools: add Wan 2.7 and Qwen-Image 2.0 providers via DashScope

### DIFF
--- a/tests/tools/test_dashscope_providers.py
+++ b/tests/tools/test_dashscope_providers.py
@@ -1,0 +1,463 @@
+"""Tests for DashScope-backed providers: wan_image, qwen_image, wan_video_api.
+
+The DashScope API is never actually called — ``requests.post`` / ``requests.get``
+are replaced with fakes scoped to the module each tool imports from. Every
+happy path walks the full submit -> poll -> download sequence so regressions in
+the shared ``tools/_dashscope.py`` helper surface immediately.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tools import _dashscope
+from tools._dashscope import DashScopeError, collect_asset_urls, poll_task, submit_task
+from tools.base_tool import ToolStatus
+from tools.graphics.qwen_image import QWEN_IMAGE_MODELS, QwenImage
+from tools.graphics.wan_image import WAN_IMAGE_MODELS, WanImage
+from tools.tool_registry import ToolRegistry
+from tools.video.wan_video_api import (
+    WAN_VIDEO_I2V_MODELS,
+    WAN_VIDEO_T2V_MODELS,
+    WanVideoAPI,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP primitives
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, payload: Any = None, *, content: bytes = b"", status: int = 200):
+        self._payload = payload
+        self.content = content
+        self.status_code = status
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeRequests:
+    """Records calls and serves queued responses."""
+
+    def __init__(self):
+        self.post_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+        self._post_queue: list[FakeResponse] = []
+        self._get_queue: list[FakeResponse] = []
+
+    def enqueue_post(self, response: FakeResponse) -> None:
+        self._post_queue.append(response)
+
+    def enqueue_get(self, response: FakeResponse) -> None:
+        self._get_queue.append(response)
+
+    def post(self, url, *, headers=None, json=None, timeout=None):
+        self.post_calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        if not self._post_queue:
+            raise AssertionError(f"Unexpected POST to {url}")
+        return self._post_queue.pop(0)
+
+    def get(self, url, *, headers=None, timeout=None):
+        self.get_calls.append({"url": url, "headers": headers, "timeout": timeout})
+        if not self._get_queue:
+            raise AssertionError(f"Unexpected GET to {url}")
+        return self._get_queue.pop(0)
+
+
+@pytest.fixture
+def fake_requests(monkeypatch):
+    fake = FakeRequests()
+
+    class _RequestsModule:
+        post = staticmethod(fake.post)
+        get = staticmethod(fake.get)
+        RequestException = RuntimeError  # satisfy ``requests.RequestException`` imports
+
+    monkeypatch.setitem(__import__("sys").modules, "requests", _RequestsModule)
+    return fake
+
+
+@pytest.fixture
+def api_key_env(monkeypatch):
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-test-123")
+    # Ensure the alt var does not also leak in from the real env
+    monkeypatch.delenv("ALIBABA_DASHSCOPE_API_KEY", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Registry discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_registry():
+    reg = ToolRegistry()
+    reg.discover("tools")
+    return reg
+
+
+def test_registry_registers_three_new_tools(fresh_registry):
+    for name in ("wan_image", "qwen_image", "wan_video_api"):
+        assert fresh_registry.get(name) is not None, f"{name} missing from registry"
+
+
+def test_registry_does_not_collide_with_local_wan_video(fresh_registry):
+    assert fresh_registry.get("wan_video") is not None
+    assert fresh_registry.get("wan_video_api") is not None
+    assert fresh_registry.get("wan_video") is not fresh_registry.get("wan_video_api")
+
+
+def test_image_capability_includes_wan_and_qwen(fresh_registry):
+    names = {t.name for t in fresh_registry.get_by_capability("image_generation")}
+    assert {"wan_image", "qwen_image"}.issubset(names)
+
+
+def test_video_capability_includes_wan_video_api(fresh_registry):
+    names = {t.name for t in fresh_registry.get_by_capability("video_generation")}
+    assert "wan_video_api" in names
+
+
+# ---------------------------------------------------------------------------
+# Metadata / status / cost
+# ---------------------------------------------------------------------------
+
+
+def test_wan_image_metadata_exposes_all_four_models():
+    info = WanImage().get_info()
+    assert set(info["provider_matrix"].keys()) == set(WAN_IMAGE_MODELS.keys())
+    assert "wan2.7-image-pro" in info["input_schema"]["properties"]["model"]["enum"]
+
+
+def test_qwen_image_metadata_exposes_all_four_models():
+    info = QwenImage().get_info()
+    assert set(info["provider_matrix"].keys()) == set(QWEN_IMAGE_MODELS.keys())
+    assert "qwen-image-2.0-pro" in info["input_schema"]["properties"]["model"]["enum"]
+
+
+def test_wan_video_api_covers_t2v_and_i2v_models():
+    info = WanVideoAPI().get_info()
+    matrix_keys = set(info["provider_matrix"].keys())
+    assert set(WAN_VIDEO_T2V_MODELS.keys()).issubset(matrix_keys)
+    assert set(WAN_VIDEO_I2V_MODELS.keys()).issubset(matrix_keys)
+    # Matrix entries carry the operation they belong to so agents can route.
+    assert info["provider_matrix"]["wan2.7-t2v"]["operation"] == "text_to_video"
+    assert info["provider_matrix"]["wan2.7-i2v"]["operation"] == "image_to_video"
+
+
+def test_status_is_unavailable_without_api_key(monkeypatch):
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ALIBABA_DASHSCOPE_API_KEY", raising=False)
+    assert WanImage().get_status() == ToolStatus.UNAVAILABLE
+    assert QwenImage().get_status() == ToolStatus.UNAVAILABLE
+    assert WanVideoAPI().get_status() == ToolStatus.UNAVAILABLE
+
+
+def test_status_is_available_with_api_key(api_key_env):
+    assert WanImage().get_status() == ToolStatus.AVAILABLE
+    assert QwenImage().get_status() == ToolStatus.AVAILABLE
+    assert WanVideoAPI().get_status() == ToolStatus.AVAILABLE
+
+
+def test_wan_image_cost_scales_with_n():
+    tool = WanImage()
+    assert tool.estimate_cost({"model": "wan2.7-image-pro", "n": 1}) == pytest.approx(0.12)
+    assert tool.estimate_cost({"model": "wan2.7-image-pro", "n": 3}) == pytest.approx(0.36)
+
+
+def test_qwen_image_cost_uses_model_table():
+    tool = QwenImage()
+    assert tool.estimate_cost({"model": "qwen-image-2.0-pro"}) == pytest.approx(0.10)
+    assert tool.estimate_cost({"model": "qwen-image"}) == pytest.approx(0.02)
+
+
+def test_wan_video_api_cost_scales_with_duration():
+    tool = WanVideoAPI()
+    assert tool.estimate_cost({"operation": "text_to_video", "model": "wan2.7-t2v", "duration": 5}) == pytest.approx(2.00)
+    assert tool.estimate_cost({"operation": "image_to_video", "model": "wan2.6-i2v-flash", "duration": 6}) == pytest.approx(1.20)
+
+
+def test_wan_video_api_cost_tolerates_invalid_model():
+    # Cost estimation should not raise if the caller hasn't validated yet.
+    assert WanVideoAPI().estimate_cost({"operation": "text_to_video", "model": "bogus"}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# DashScope helper: happy path, terminal failure, timeout
+# ---------------------------------------------------------------------------
+
+
+def test_submit_task_includes_async_header(fake_requests):
+    fake_requests.enqueue_post(FakeResponse({"output": {"task_id": "t-1", "task_status": "PENDING"}}))
+    task_id = submit_task("services/aigc/text2image/image-synthesis", {"model": "wan2.7-image"}, "sk-x")
+    assert task_id == "t-1"
+    call = fake_requests.post_calls[0]
+    assert call["headers"]["Authorization"] == "Bearer sk-x"
+    assert call["headers"]["X-DashScope-Async"] == "enable"
+    assert call["url"].endswith("/services/aigc/text2image/image-synthesis")
+
+
+def test_submit_task_raises_when_no_task_id(fake_requests):
+    fake_requests.enqueue_post(FakeResponse({"output": {}}))
+    with pytest.raises(DashScopeError):
+        submit_task("services/aigc/text2image/image-synthesis", {}, "sk-x")
+
+
+def test_poll_task_transitions_running_to_succeeded(fake_requests):
+    fake_requests.enqueue_get(FakeResponse({"output": {"task_status": "RUNNING"}}))
+    fake_requests.enqueue_get(
+        FakeResponse({"output": {"task_status": "SUCCEEDED", "results": [{"url": "https://asset/one.png"}]}})
+    )
+    sleeps: list[float] = []
+    output = poll_task("t-1", "sk-x", timeout=60, initial_interval=0.0, max_interval=0.0, sleep=sleeps.append)
+    assert output["task_status"] == "SUCCEEDED"
+    assert collect_asset_urls(output) == ["https://asset/one.png"]
+    assert sleeps  # polled at least once
+
+
+def test_poll_task_raises_on_failure(fake_requests):
+    fake_requests.enqueue_get(FakeResponse({"output": {"task_status": "FAILED", "message": "bad prompt"}}))
+    with pytest.raises(DashScopeError) as exc_info:
+        poll_task("t-1", "sk-x", timeout=10, initial_interval=0.0, sleep=lambda _s: None)
+    assert "FAILED" in str(exc_info.value)
+    assert "bad prompt" in str(exc_info.value)
+
+
+def test_collect_asset_urls_handles_single_video_url():
+    assert collect_asset_urls({"video_url": "https://v/one.mp4"}) == ["https://v/one.mp4"]
+    assert collect_asset_urls({"results": [{"url": "a"}, {"url": "b"}]}) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tool execution with the fake HTTP layer
+# ---------------------------------------------------------------------------
+
+
+def _submit_response(task_id: str = "t-1"):
+    return FakeResponse({"output": {"task_id": task_id, "task_status": "PENDING"}})
+
+
+def _succeeded_image(url: str = "https://cdn/img.png"):
+    return FakeResponse({"output": {"task_status": "SUCCEEDED", "results": [{"url": url}]}})
+
+
+def _succeeded_video(url: str = "https://cdn/clip.mp4"):
+    return FakeResponse({"output": {"task_status": "SUCCEEDED", "video_url": url}})
+
+
+def test_wan_image_happy_path_submits_polls_downloads(
+    fake_requests, api_key_env, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_dashscope.time, "sleep", lambda _s: None)
+    fake_requests.enqueue_post(_submit_response("task-img-1"))
+    fake_requests.enqueue_get(FakeResponse({"output": {"task_status": "RUNNING"}}))
+    fake_requests.enqueue_get(_succeeded_image())
+    fake_requests.enqueue_get(FakeResponse(content=b"PNG_BYTES"))
+
+    output_path = tmp_path / "out.png"
+    result = WanImage().execute(
+        {
+            "prompt": "A red panda coding in neon light",
+            "model": "wan2.7-image-pro",
+            "n": 1,
+            "size": "1024*1024",
+            "seed": 42,
+            "output_path": str(output_path),
+        }
+    )
+    assert result.success, result.error
+    assert output_path.read_bytes() == b"PNG_BYTES"
+    assert result.data["task_id"] == "task-img-1"
+    assert result.data["provider"] == "wan"
+    assert result.data["model"] == "wan2.7-image-pro"
+    assert result.cost_usd == pytest.approx(0.12)
+
+    submit = fake_requests.post_calls[0]
+    body = submit["json"]
+    assert body["model"] == "wan2.7-image-pro"
+    assert body["input"]["prompt"].startswith("A red panda")
+    assert body["parameters"]["seed"] == 42
+
+
+def test_wan_image_multi_image_batch_writes_all_files(
+    fake_requests, api_key_env, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_dashscope.time, "sleep", lambda _s: None)
+    fake_requests.enqueue_post(_submit_response("batch-1"))
+    fake_requests.enqueue_get(
+        FakeResponse({"output": {"task_status": "SUCCEEDED", "results": [
+            {"url": "https://cdn/1.png"},
+            {"url": "https://cdn/2.png"},
+        ]}})
+    )
+    fake_requests.enqueue_get(FakeResponse(content=b"A"))
+    fake_requests.enqueue_get(FakeResponse(content=b"B"))
+
+    base = tmp_path / "img.png"
+    result = WanImage().execute(
+        {"prompt": "x", "n": 2, "output_path": str(base)}
+    )
+    assert result.success, result.error
+    assert (tmp_path / "img_0.png").read_bytes() == b"A"
+    assert (tmp_path / "img_1.png").read_bytes() == b"B"
+    assert result.data["outputs"] == [str(tmp_path / "img_0.png"), str(tmp_path / "img_1.png")]
+
+
+def test_wan_image_returns_error_when_key_missing(monkeypatch):
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ALIBABA_DASHSCOPE_API_KEY", raising=False)
+    result = WanImage().execute({"prompt": "x"})
+    assert not result.success
+    assert "DASHSCOPE_API_KEY" in (result.error or "")
+
+
+def test_wan_image_rejects_unknown_model(api_key_env):
+    result = WanImage().execute({"prompt": "x", "model": "not-a-real-model"})
+    assert not result.success
+    assert "Unknown model" in (result.error or "")
+
+
+def test_qwen_image_happy_path(fake_requests, api_key_env, tmp_path, monkeypatch):
+    monkeypatch.setattr(_dashscope.time, "sleep", lambda _s: None)
+    fake_requests.enqueue_post(_submit_response("task-q-1"))
+    fake_requests.enqueue_get(_succeeded_image("https://cdn/q.png"))
+    fake_requests.enqueue_get(FakeResponse(content=b"QIMG"))
+
+    out = tmp_path / "q.png"
+    result = QwenImage().execute(
+        {"prompt": "poster with 中文 caption", "model": "qwen-image-2.0-pro", "output_path": str(out)}
+    )
+    assert result.success, result.error
+    assert out.read_bytes() == b"QIMG"
+    assert result.data["provider"] == "qwen"
+    assert result.cost_usd == pytest.approx(0.10)
+
+
+def test_qwen_image_returns_error_when_key_missing(monkeypatch):
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ALIBABA_DASHSCOPE_API_KEY", raising=False)
+    result = QwenImage().execute({"prompt": "x"})
+    assert not result.success
+    assert "DASHSCOPE_API_KEY" in (result.error or "")
+
+
+def test_wan_video_api_text_to_video_happy_path(
+    fake_requests, api_key_env, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_dashscope.time, "sleep", lambda _s: None)
+    fake_requests.enqueue_post(_submit_response("task-t2v-1"))
+    fake_requests.enqueue_get(_succeeded_video())
+    fake_requests.enqueue_get(FakeResponse(content=b"MP4_BYTES"))
+
+    out = tmp_path / "clip.mp4"
+    result = WanVideoAPI().execute(
+        {
+            "prompt": "A drone shot over misty mountains at dawn",
+            "operation": "text_to_video",
+            "model": "wan2.7-t2v",
+            "duration": 5,
+            "output_path": str(out),
+        }
+    )
+    assert result.success, result.error
+    assert out.read_bytes() == b"MP4_BYTES"
+    assert result.data["provider"] == "wan"
+    assert result.data["model"] == "wan2.7-t2v"
+    assert result.data["operation"] == "text_to_video"
+    assert result.data["format"] == "mp4"
+
+    submit_url = fake_requests.post_calls[0]["url"]
+    assert "text2video" in submit_url or "video-generation" in submit_url
+
+
+def test_wan_video_api_image_to_video_requires_img_url(api_key_env):
+    result = WanVideoAPI().execute(
+        {
+            "prompt": "dolphin leaps",
+            "operation": "image_to_video",
+            "model": "wan2.7-i2v",
+        }
+    )
+    assert not result.success
+    assert "img_url" in (result.error or "")
+
+
+def test_wan_video_api_image_to_video_happy_path(
+    fake_requests, api_key_env, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_dashscope.time, "sleep", lambda _s: None)
+    fake_requests.enqueue_post(_submit_response("task-i2v-1"))
+    fake_requests.enqueue_get(_succeeded_video("https://cdn/i2v.mp4"))
+    fake_requests.enqueue_get(FakeResponse(content=b"I2V_BYTES"))
+
+    out = tmp_path / "i2v.mp4"
+    result = WanVideoAPI().execute(
+        {
+            "prompt": "The subject walks forward",
+            "operation": "image_to_video",
+            "model": "wan2.6-i2v-flash",
+            "img_url": "https://example.com/ref.png",
+            "output_path": str(out),
+        }
+    )
+    assert result.success, result.error
+    assert out.read_bytes() == b"I2V_BYTES"
+    assert result.data["operation"] == "image_to_video"
+    # Submit hit the image2video endpoint
+    assert "image2video" in fake_requests.post_calls[0]["url"]
+    # And the image URL was threaded through
+    assert fake_requests.post_calls[0]["json"]["input"]["img_url"] == "https://example.com/ref.png"
+
+
+def test_wan_video_api_rejects_t2v_model_on_i2v_operation(api_key_env):
+    result = WanVideoAPI().execute(
+        {
+            "prompt": "x",
+            "operation": "image_to_video",
+            "model": "wan2.7-t2v",  # t2v model on i2v op
+            "img_url": "https://example.com/ref.png",
+        }
+    )
+    assert not result.success
+    assert "image-to-video" in (result.error or "")
+
+
+def test_wan_video_api_rejects_i2v_model_on_t2v_operation(api_key_env):
+    result = WanVideoAPI().execute(
+        {
+            "prompt": "x",
+            "operation": "text_to_video",
+            "model": "wan2.7-i2v",  # i2v model on t2v op
+        }
+    )
+    assert not result.success
+    assert "text-to-video" in (result.error or "")
+
+
+def test_wan_video_api_returns_error_when_key_missing(monkeypatch):
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ALIBABA_DASHSCOPE_API_KEY", raising=False)
+    result = WanVideoAPI().execute({"prompt": "x"})
+    assert not result.success
+    assert "DASHSCOPE_API_KEY" in (result.error or "")
+
+
+def test_wan_video_api_bubbles_up_dashscope_failure(
+    fake_requests, api_key_env, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_dashscope.time, "sleep", lambda _s: None)
+    fake_requests.enqueue_post(_submit_response("task-fail"))
+    fake_requests.enqueue_get(
+        FakeResponse({"output": {"task_status": "FAILED", "message": "prompt rejected"}})
+    )
+    result = WanVideoAPI().execute(
+        {"prompt": "x", "operation": "text_to_video", "model": "wan2.7-t2v", "output_path": str(tmp_path / "x.mp4")}
+    )
+    assert not result.success
+    assert "prompt rejected" in (result.error or "")

--- a/tools/_dashscope.py
+++ b/tools/_dashscope.py
@@ -1,0 +1,145 @@
+"""Shared helper for Alibaba DashScope async generation APIs.
+
+DashScope (Aliyun Model Studio) exposes text-to-image, text-to-video, and
+image-to-video via a three-step async protocol:
+
+1. POST the generation request with header ``X-DashScope-Async: enable`` ->
+   returns a ``task_id``.
+2. GET ``/api/v1/tasks/{task_id}`` until the task reaches a terminal state
+   (``SUCCEEDED``, ``FAILED``, ``CANCELED``, ``UNKNOWN``).
+3. Download the produced image/video asset from the URLs in the result.
+
+This module centralizes the HTTP + polling mechanics so the per-model tool
+classes (``wan_image``, ``qwen_image``, ``wan_video_api``) stay thin.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Optional
+
+
+DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/api/v1"
+
+TERMINAL_STATUSES = {"SUCCEEDED", "FAILED", "CANCELED", "UNKNOWN"}
+
+
+class DashScopeError(RuntimeError):
+    """Raised for any non-recoverable DashScope API failure."""
+
+
+def get_api_key() -> Optional[str]:
+    """Return the DashScope API key from environment, if set."""
+    return os.environ.get("DASHSCOPE_API_KEY") or os.environ.get("ALIBABA_DASHSCOPE_API_KEY")
+
+
+def install_instructions() -> str:
+    return (
+        "Set DASHSCOPE_API_KEY to your Alibaba Cloud Model Studio API key.\n"
+        "  Get one at https://bailian.console.aliyun.com/?apiKey=1"
+    )
+
+
+def submit_task(
+    endpoint: str,
+    payload: dict[str, Any],
+    api_key: str,
+    *,
+    timeout: int = 60,
+) -> str:
+    """Submit an async DashScope task and return its ``task_id``.
+
+    ``endpoint`` is the path relative to ``DASHSCOPE_BASE_URL`` — for example
+    ``services/aigc/text2image/image-synthesis``.
+    """
+    import requests
+
+    url = f"{DASHSCOPE_BASE_URL}/{endpoint.lstrip('/')}"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "X-DashScope-Async": "enable",
+        "Content-Type": "application/json",
+    }
+    response = requests.post(url, headers=headers, json=payload, timeout=timeout)
+    response.raise_for_status()
+    data = response.json()
+    task_id = (data.get("output") or {}).get("task_id")
+    if not task_id:
+        raise DashScopeError(f"No task_id in DashScope response: {data}")
+    return task_id
+
+
+def poll_task(
+    task_id: str,
+    api_key: str,
+    *,
+    timeout: int = 600,
+    initial_interval: float = 3.0,
+    max_interval: float = 15.0,
+    sleep: Any = time.sleep,
+) -> dict[str, Any]:
+    """Poll a DashScope task until it reaches a terminal state.
+
+    Returns the full ``output`` block. Raises :class:`DashScopeError` when the
+    task ends in a non-``SUCCEEDED`` terminal state. ``sleep`` is injectable
+    to keep unit tests fast.
+    """
+    import requests
+
+    url = f"{DASHSCOPE_BASE_URL}/tasks/{task_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    deadline = time.time() + timeout
+    interval = initial_interval
+
+    while True:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        payload = response.json()
+        output = payload.get("output") or {}
+        status = (output.get("task_status") or "").upper()
+
+        if status == "SUCCEEDED":
+            return output
+        if status in TERMINAL_STATUSES:
+            message = output.get("message") or output.get("code") or payload
+            raise DashScopeError(f"DashScope task {task_id} ended as {status}: {message}")
+
+        if time.time() >= deadline:
+            raise DashScopeError(f"DashScope task {task_id} timed out after {timeout}s (last status={status!r})")
+
+        sleep(min(interval, max(0.5, deadline - time.time())))
+        interval = min(interval * 1.5, max_interval)
+
+
+def download_asset(url: str, *, timeout: int = 180) -> bytes:
+    """Download the bytes for a produced asset URL."""
+    import requests
+
+    response = requests.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response.content
+
+
+def collect_asset_urls(output: dict[str, Any], *, key: str = "url") -> list[str]:
+    """Extract asset URLs from a successful DashScope output block.
+
+    DashScope varies across capabilities:
+      - text-to-image returns ``output.results = [{"url": "..."}, ...]``
+      - text-to-video / image-to-video returns ``output.video_url`` (single)
+        or ``output.results = [{"url": "..."}]`` depending on the model.
+    """
+    urls: list[str] = []
+    results = output.get("results")
+    if isinstance(results, list):
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            value = item.get(key) or item.get("url")
+            if value:
+                urls.append(value)
+    for single_key in ("video_url", "image_url", "url"):
+        value = output.get(single_key)
+        if value and value not in urls:
+            urls.append(value)
+    return urls

--- a/tools/graphics/qwen_image.py
+++ b/tools/graphics/qwen_image.py
@@ -1,0 +1,196 @@
+"""Qwen-Image text-to-image generation via Alibaba DashScope (Model Studio).
+
+Covers the Qwen-Image 2.0 family. Uses the same async DashScope protocol as
+``wan_image`` but with Qwen-specific model IDs and cost profile.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from tools._dashscope import (
+    DashScopeError,
+    collect_asset_urls,
+    download_asset,
+    get_api_key,
+    install_instructions,
+    poll_task,
+    submit_task,
+)
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+QWEN_IMAGE_MODELS: dict[str, dict[str, Any]] = {
+    "qwen-image-2.0-pro": {"name": "Qwen-Image 2.0 Pro", "cost_per_image": 0.10, "quality": "highest"},
+    "qwen-image-2.0": {"name": "Qwen-Image 2.0", "cost_per_image": 0.05, "quality": "high"},
+    "qwen-image-plus": {"name": "Qwen-Image Plus", "cost_per_image": 0.04, "quality": "high"},
+    "qwen-image": {"name": "Qwen-Image", "cost_per_image": 0.02, "quality": "medium"},
+}
+
+
+class QwenImage(BaseTool):
+    name = "qwen_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "qwen"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.SEEDED
+    runtime = ToolRuntime.API
+
+    dependencies: list[str] = []
+    install_instructions = install_instructions()
+    agent_skills = ["flux-best-practices"]
+    fallback_tools = ["wan_image", "flux_image", "google_imagen"]
+
+    capabilities = ["text_to_image", "render_text_in_image"]
+    supports = {
+        "negative_prompt": True,
+        "seed": True,
+        "custom_size": True,
+        "batch": True,
+        "chinese_text_rendering": True,
+    }
+    best_for = [
+        "renders readable text inside images (CN + EN)",
+        "Chinese cultural imagery and poster design",
+        "infographics that need legible captions",
+    ]
+    not_good_for = ["offline generation", "regions without DashScope access"]
+    provider_matrix = {
+        model_id: {"tool": "qwen_image", "mode": "dashscope", **meta}
+        for model_id, meta in QWEN_IMAGE_MODELS.items()
+    }
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "model": {"type": "string", "enum": sorted(QWEN_IMAGE_MODELS), "default": "qwen-image-2.0-pro"},
+            "negative_prompt": {"type": "string"},
+            "size": {"type": "string", "default": "1328*1328"},
+            "n": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1},
+            "seed": {"type": "integer"},
+            "prompt_extend": {"type": "boolean", "default": True},
+            "watermark": {"type": "boolean", "default": False},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "model", "size", "seed", "n"]
+    side_effects = ["writes image file(s) to output_path", "calls DashScope API"]
+    user_visible_verification = ["Inspect generated image for relevance and quality"]
+
+    def get_status(self) -> ToolStatus:
+        if get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        meta = QWEN_IMAGE_MODELS.get(
+            inputs.get("model", "qwen-image-2.0-pro"), QWEN_IMAGE_MODELS["qwen-image-2.0-pro"]
+        )
+        n = int(inputs.get("n", 1) or 1)
+        return round(meta["cost_per_image"] * max(1, n), 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 20.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = get_api_key()
+        if not api_key:
+            return ToolResult(success=False, error="DASHSCOPE_API_KEY not set. " + self.install_instructions)
+
+        model = inputs.get("model", "qwen-image-2.0-pro")
+        if model not in QWEN_IMAGE_MODELS:
+            return ToolResult(
+                success=False,
+                error=f"Unknown model: {model}. Available: {', '.join(sorted(QWEN_IMAGE_MODELS))}",
+            )
+
+        prompt = inputs["prompt"]
+        parameters: dict[str, Any] = {
+            "size": inputs.get("size", "1328*1328"),
+            "n": int(inputs.get("n", 1) or 1),
+            "prompt_extend": bool(inputs.get("prompt_extend", True)),
+            "watermark": bool(inputs.get("watermark", False)),
+        }
+        if inputs.get("seed") is not None:
+            parameters["seed"] = int(inputs["seed"])
+
+        body: dict[str, Any] = {
+            "model": model,
+            "input": {"prompt": prompt},
+            "parameters": parameters,
+        }
+        if inputs.get("negative_prompt"):
+            body["input"]["negative_prompt"] = inputs["negative_prompt"]
+
+        start = time.time()
+        try:
+            task_id = submit_task(
+                "services/aigc/text2image/image-synthesis",
+                body,
+                api_key,
+            )
+            output = poll_task(task_id, api_key, timeout=300)
+            urls = collect_asset_urls(output)
+            if not urls:
+                return ToolResult(success=False, error=f"DashScope returned no image URLs: {output}")
+
+            base_output = Path(inputs.get("output_path", f"{model.replace('.', '_')}_{task_id}.png"))
+            base_output.parent.mkdir(parents=True, exist_ok=True)
+            written: list[str] = []
+            for idx, url in enumerate(urls):
+                if len(urls) == 1:
+                    target = base_output
+                else:
+                    stem, suffix = base_output.stem, base_output.suffix or ".png"
+                    target = base_output.with_name(f"{stem}_{idx}{suffix}")
+                target.write_bytes(download_asset(url))
+                written.append(str(target))
+        except DashScopeError as exc:
+            return ToolResult(success=False, error=f"Qwen image generation failed: {exc}")
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Qwen image generation failed: {exc}")
+
+        meta = QWEN_IMAGE_MODELS[model]
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "qwen",
+                "provider_name": meta["name"],
+                "mode": "dashscope",
+                "model": model,
+                "prompt": prompt,
+                "output": written[0],
+                "outputs": written,
+                "task_id": task_id,
+                "size": parameters["size"],
+                "n": parameters["n"],
+            },
+            artifacts=written,
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            seed=inputs.get("seed"),
+            model=model,
+        )

--- a/tools/graphics/wan_image.py
+++ b/tools/graphics/wan_image.py
@@ -1,0 +1,194 @@
+"""Wan text-to-image generation via Alibaba DashScope (Model Studio).
+
+Covers the Wan 2.2 / 2.7 image family exposed through DashScope's
+``services/aigc/text2image/image-synthesis`` async endpoint. Distinct
+from ``wan_video`` (local GPU) — this tool is API-only.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from tools._dashscope import (
+    DashScopeError,
+    collect_asset_urls,
+    download_asset,
+    get_api_key,
+    install_instructions,
+    poll_task,
+    submit_task,
+)
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+WAN_IMAGE_MODELS: dict[str, dict[str, Any]] = {
+    "wan2.7-image-pro": {"name": "Wan 2.7 Image Pro", "cost_per_image": 0.12, "quality": "highest"},
+    "wan2.7-image": {"name": "Wan 2.7 Image", "cost_per_image": 0.06, "quality": "high"},
+    "wan2.2-t2i-plus": {"name": "Wan 2.2 T2I Plus", "cost_per_image": 0.05, "quality": "high"},
+    "wan2.2-t2i-flash": {"name": "Wan 2.2 T2I Flash", "cost_per_image": 0.02, "quality": "medium"},
+}
+
+
+class WanImage(BaseTool):
+    name = "wan_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "wan"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.SEEDED
+    runtime = ToolRuntime.API
+
+    dependencies: list[str] = []  # checked dynamically via env var
+    install_instructions = install_instructions()
+    agent_skills = ["flux-best-practices"]
+    fallback_tools = ["qwen_image", "flux_image", "google_imagen"]
+
+    capabilities = ["text_to_image", "generate_illustration"]
+    supports = {
+        "negative_prompt": True,
+        "seed": True,
+        "custom_size": True,
+        "batch": True,
+    }
+    best_for = [
+        "Wan 2.7 photoreal + stylised imagery via Alibaba DashScope",
+        "Chinese prompts and Chinese cultural context",
+        "multi-image batch generation (up to 4 per call)",
+    ]
+    not_good_for = ["offline generation", "regions without DashScope access"]
+    provider_matrix = {
+        model_id: {"tool": "wan_image", "mode": "dashscope", **meta}
+        for model_id, meta in WAN_IMAGE_MODELS.items()
+    }
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "model": {"type": "string", "enum": sorted(WAN_IMAGE_MODELS), "default": "wan2.7-image-pro"},
+            "negative_prompt": {"type": "string"},
+            "size": {"type": "string", "default": "1024*1024"},
+            "n": {"type": "integer", "minimum": 1, "maximum": 4, "default": 1},
+            "seed": {"type": "integer"},
+            "prompt_extend": {"type": "boolean", "default": True},
+            "watermark": {"type": "boolean", "default": False},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "model", "size", "seed", "n"]
+    side_effects = ["writes image file(s) to output_path", "calls DashScope API"]
+    user_visible_verification = ["Inspect generated image for relevance and quality"]
+
+    def get_status(self) -> ToolStatus:
+        if get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        meta = WAN_IMAGE_MODELS.get(inputs.get("model", "wan2.7-image-pro"), WAN_IMAGE_MODELS["wan2.7-image-pro"])
+        n = int(inputs.get("n", 1) or 1)
+        return round(meta["cost_per_image"] * max(1, n), 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 20.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = get_api_key()
+        if not api_key:
+            return ToolResult(success=False, error="DASHSCOPE_API_KEY not set. " + self.install_instructions)
+
+        model = inputs.get("model", "wan2.7-image-pro")
+        if model not in WAN_IMAGE_MODELS:
+            return ToolResult(
+                success=False,
+                error=f"Unknown model: {model}. Available: {', '.join(sorted(WAN_IMAGE_MODELS))}",
+            )
+
+        prompt = inputs["prompt"]
+        parameters: dict[str, Any] = {
+            "size": inputs.get("size", "1024*1024"),
+            "n": int(inputs.get("n", 1) or 1),
+            "prompt_extend": bool(inputs.get("prompt_extend", True)),
+            "watermark": bool(inputs.get("watermark", False)),
+        }
+        if inputs.get("seed") is not None:
+            parameters["seed"] = int(inputs["seed"])
+
+        body: dict[str, Any] = {
+            "model": model,
+            "input": {"prompt": prompt},
+            "parameters": parameters,
+        }
+        if inputs.get("negative_prompt"):
+            body["input"]["negative_prompt"] = inputs["negative_prompt"]
+
+        start = time.time()
+        try:
+            task_id = submit_task(
+                "services/aigc/text2image/image-synthesis",
+                body,
+                api_key,
+            )
+            output = poll_task(task_id, api_key, timeout=300)
+            urls = collect_asset_urls(output)
+            if not urls:
+                return ToolResult(success=False, error=f"DashScope returned no image URLs: {output}")
+
+            base_output = Path(inputs.get("output_path", f"{model.replace('.', '_')}_{task_id}.png"))
+            base_output.parent.mkdir(parents=True, exist_ok=True)
+            written: list[str] = []
+            for idx, url in enumerate(urls):
+                if len(urls) == 1:
+                    target = base_output
+                else:
+                    stem, suffix = base_output.stem, base_output.suffix or ".png"
+                    target = base_output.with_name(f"{stem}_{idx}{suffix}")
+                target.write_bytes(download_asset(url))
+                written.append(str(target))
+        except DashScopeError as exc:
+            return ToolResult(success=False, error=f"Wan image generation failed: {exc}")
+        except Exception as exc:  # requests.RequestException etc.
+            return ToolResult(success=False, error=f"Wan image generation failed: {exc}")
+
+        meta = WAN_IMAGE_MODELS[model]
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "wan",
+                "provider_name": meta["name"],
+                "mode": "dashscope",
+                "model": model,
+                "prompt": prompt,
+                "output": written[0],
+                "outputs": written,
+                "task_id": task_id,
+                "size": parameters["size"],
+                "n": parameters["n"],
+            },
+            artifacts=written,
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            seed=inputs.get("seed"),
+            model=model,
+        )

--- a/tools/video/wan_video_api.py
+++ b/tools/video/wan_video_api.py
@@ -1,0 +1,240 @@
+"""Wan video generation via Alibaba DashScope (Model Studio).
+
+Covers both text-to-video (``wan2.7-t2v``, ``wan2.5-t2v-plus``,
+``wan2.2-t2v-plus``) and image-to-video (``wan2.7-i2v``, ``wan2.6-i2v-flash``,
+``wan2.5-i2v-plus``) against DashScope's async video-synthesis endpoints.
+
+Named ``wan_video_api`` to coexist with the local-GPU ``wan_video`` tool.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from tools._dashscope import (
+    DashScopeError,
+    collect_asset_urls,
+    download_asset,
+    get_api_key,
+    install_instructions,
+    poll_task,
+    submit_task,
+)
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+WAN_VIDEO_T2V_MODELS: dict[str, dict[str, Any]] = {
+    "wan2.7-t2v": {"name": "Wan 2.7 Text-to-Video", "cost_per_second": 0.40, "quality": "highest"},
+    "wan2.5-t2v-plus": {"name": "Wan 2.5 T2V Plus", "cost_per_second": 0.30, "quality": "high"},
+    "wan2.2-t2v-plus": {"name": "Wan 2.2 T2V Plus", "cost_per_second": 0.20, "quality": "high"},
+}
+
+WAN_VIDEO_I2V_MODELS: dict[str, dict[str, Any]] = {
+    "wan2.7-i2v": {"name": "Wan 2.7 Image-to-Video", "cost_per_second": 0.45, "quality": "highest"},
+    "wan2.6-i2v-flash": {"name": "Wan 2.6 I2V Flash", "cost_per_second": 0.20, "quality": "high"},
+    "wan2.5-i2v-plus": {"name": "Wan 2.5 I2V Plus", "cost_per_second": 0.30, "quality": "high"},
+}
+
+T2V_ENDPOINT = "services/aigc/video-generation/video-synthesis"
+I2V_ENDPOINT = "services/aigc/image2video/video-synthesis"
+
+
+class WanVideoAPI(BaseTool):
+    name = "wan_video_api"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "wan"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies: list[str] = []
+    install_instructions = install_instructions()
+    agent_skills = ["ai-video-gen"]
+    fallback_tools = ["wan_video", "kling_video", "minimax_video", "veo_video"]
+
+    capabilities = ["text_to_video", "image_to_video"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "reference_image": True,
+        "offline": False,
+        "native_audio": False,
+    }
+    best_for = [
+        "Wan 2.7 t2v and i2v via Alibaba DashScope (no local GPU needed)",
+        "strong motion coherence and physics",
+        "Chinese prompts and localized cultural content",
+    ]
+    not_good_for = ["offline generation", "regions without DashScope access"]
+    provider_matrix = {
+        **{mid: {"tool": "wan_video_api", "mode": "dashscope", "operation": "text_to_video", **meta}
+           for mid, meta in WAN_VIDEO_T2V_MODELS.items()},
+        **{mid: {"tool": "wan_video_api", "mode": "dashscope", "operation": "image_to_video", **meta}
+           for mid, meta in WAN_VIDEO_I2V_MODELS.items()},
+    }
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video"],
+                "default": "text_to_video",
+            },
+            "model": {
+                "type": "string",
+                "enum": sorted({*WAN_VIDEO_T2V_MODELS, *WAN_VIDEO_I2V_MODELS}),
+            },
+            "img_url": {"type": "string", "description": "Reference image URL (required for image_to_video)"},
+            "negative_prompt": {"type": "string"},
+            "size": {"type": "string"},
+            "duration": {"type": "integer", "minimum": 3, "maximum": 10, "default": 5},
+            "prompt_extend": {"type": "boolean", "default": True},
+            "seed": {"type": "integer"},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "model", "operation", "img_url", "seed"]
+    side_effects = ["writes video file to output_path", "calls DashScope API"]
+    user_visible_verification = ["Watch generated clip for motion coherence and artifacts"]
+
+    def get_status(self) -> ToolStatus:
+        if get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def _resolve_model(self, inputs: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
+        """Return (operation, model, meta). Raises ValueError on mismatch."""
+        operation = inputs.get("operation", "text_to_video")
+        if operation not in {"text_to_video", "image_to_video"}:
+            raise ValueError(f"operation must be text_to_video or image_to_video, got {operation!r}")
+
+        if operation == "text_to_video":
+            model = inputs.get("model", "wan2.7-t2v")
+            if model not in WAN_VIDEO_T2V_MODELS:
+                raise ValueError(
+                    f"Model {model!r} is not a Wan text-to-video model. "
+                    f"Available: {', '.join(sorted(WAN_VIDEO_T2V_MODELS))}"
+                )
+            return operation, model, WAN_VIDEO_T2V_MODELS[model]
+
+        model = inputs.get("model", "wan2.7-i2v")
+        if model not in WAN_VIDEO_I2V_MODELS:
+            raise ValueError(
+                f"Model {model!r} is not a Wan image-to-video model. "
+                f"Available: {', '.join(sorted(WAN_VIDEO_I2V_MODELS))}"
+            )
+        return operation, model, WAN_VIDEO_I2V_MODELS[model]
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        try:
+            _operation, _model, meta = self._resolve_model(inputs)
+        except ValueError:
+            return 0.0
+        duration = int(inputs.get("duration", 5) or 5)
+        return round(meta["cost_per_second"] * max(1, duration), 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 120.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = get_api_key()
+        if not api_key:
+            return ToolResult(success=False, error="DASHSCOPE_API_KEY not set. " + self.install_instructions)
+
+        try:
+            operation, model, meta = self._resolve_model(inputs)
+        except ValueError as exc:
+            return ToolResult(success=False, error=str(exc))
+
+        prompt = inputs["prompt"]
+        parameters: dict[str, Any] = {
+            "duration": int(inputs.get("duration", 5) or 5),
+            "prompt_extend": bool(inputs.get("prompt_extend", True)),
+        }
+        if inputs.get("size"):
+            parameters["size"] = inputs["size"]
+        if inputs.get("seed") is not None:
+            parameters["seed"] = int(inputs["seed"])
+
+        input_block: dict[str, Any] = {"prompt": prompt}
+        if inputs.get("negative_prompt"):
+            input_block["negative_prompt"] = inputs["negative_prompt"]
+
+        if operation == "image_to_video":
+            img_url = inputs.get("img_url") or inputs.get("reference_image_url")
+            if not img_url:
+                return ToolResult(
+                    success=False,
+                    error="image_to_video requires img_url (or reference_image_url).",
+                )
+            input_block["img_url"] = img_url
+            endpoint = I2V_ENDPOINT
+        else:
+            endpoint = T2V_ENDPOINT
+
+        body = {"model": model, "input": input_block, "parameters": parameters}
+
+        start = time.time()
+        try:
+            task_id = submit_task(endpoint, body, api_key)
+            output = poll_task(task_id, api_key, timeout=900)
+            urls = collect_asset_urls(output)
+            if not urls:
+                return ToolResult(success=False, error=f"DashScope returned no video URL: {output}")
+
+            output_path = Path(inputs.get("output_path", f"wan_api_{model.replace('.', '_')}_{task_id}.mp4"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(download_asset(urls[0], timeout=300))
+        except DashScopeError as exc:
+            return ToolResult(success=False, error=f"Wan video API generation failed: {exc}")
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Wan video API generation failed: {exc}")
+
+        from tools.video._shared import probe_output
+
+        probed = probe_output(output_path)
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "wan",
+                "provider_name": meta["name"],
+                "mode": "dashscope",
+                "model": model,
+                "operation": operation,
+                "prompt": prompt,
+                "task_id": task_id,
+                "output": str(output_path),
+                "output_path": str(output_path),
+                "format": "mp4",
+                **probed,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            seed=inputs.get("seed"),
+            model=model,
+        )


### PR DESCRIPTION
## Summary

Closes #1. Adds three BaseTool providers that auto-register through the existing registry + selector pattern:

- **`wan_image`** (`image_generation`, `provider=wan`) — Wan 2.7 / 2.2 text-to-image via DashScope, including `wan2.7-image-pro` and `wan2.7-image`.
- **`qwen_image`** (`image_generation`, `provider=qwen`) — Qwen-Image 2.0 family (`qwen-image-2.0-pro`, `qwen-image-2.0`, `qwen-image-plus`, `qwen-image`).
- **`wan_video_api`** (`video_generation`, `provider=wan`) — cloud Wan video for both text-to-video (`wan2.7-t2v`, `wan2.5-t2v-plus`, `wan2.2-t2v-plus`) and image-to-video (`wan2.7-i2v`, `wan2.6-i2v-flash`, `wan2.5-i2v-plus`). Kept distinct from the local-GPU `wan_video` tool so both can coexist in the registry.

A shared `tools/_dashscope.py` helper implements the DashScope async pattern:
1. POST with `X-DashScope-Async: enable` → returns `task_id`
2. GET `/api/v1/tasks/{task_id}` until the task reaches a terminal state
3. Download the resulting image/video asset

All three tools surface `DASHSCOPE_API_KEY` in `install_instructions`, declare a `provider_matrix`, and participate in `provider_menu()` / `capability_catalog()` — no selector changes required thanks to auto-discovery.

## Issue coverage

From #1:

| Requirement | Tool | Models |
|---|---|---|
| 文生图 (wan2.7) | `wan_image` | `wan2.7-image-pro`, `wan2.7-image`, `wan2.2-t2i-plus`, `wan2.2-t2i-flash` |
| 千问文生图 | `qwen_image` | `qwen-image-2.0-pro`, `qwen-image-2.0`, `qwen-image-plus`, `qwen-image` |
| 图生视频 | `wan_video_api` (operation=`image_to_video`) | `wan2.7-i2v`, `wan2.6-i2v-flash`, `wan2.5-i2v-plus` |
| 文生视频 | `wan_video_api` (operation=`text_to_video`) | `wan2.7-t2v`, `wan2.5-t2v-plus`, `wan2.2-t2v-plus` |

## Test plan

`tests/tools/test_dashscope_providers.py` (31 tests, all green) covers:

- [x] Registry discovery — all three tools appear under the right capability and don't collide with `wan_video`.
- [x] Metadata shape — `provider_matrix`, cost scaling with `n` / duration, status flipping on `DASHSCOPE_API_KEY`.
- [x] Graceful failure — each tool returns `ToolResult(success=False)` with an actionable error when the key is missing.
- [x] Input validation — unknown models, t2v/i2v model/operation mismatches, missing `img_url` for i2v.
- [x] Happy path — submit → poll (with `RUNNING`→`SUCCEEDED` transition) → download, with `requests` faked at the boundary.
- [x] Full `tests/contracts` + `tests/tools` + remaining non-qa suites: **291 passed, 6 skipped, 0 failed**.
- [ ] End-to-end against live DashScope (requires a valid `DASHSCOPE_API_KEY` — not runnable in CI).

https://claude.ai/code/session_01K7dG2dT1QvMjoEMRyMh6ri