### PR TITLE
Qwen-TTS + Wan/Qwen skill coverage across all layers (closes #4)

### DIFF
--- a/.agents/skills/ai-video-gen/SKILL.md
+++ b/.agents/skills/ai-video-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-video-gen
 description: |
-  Generate AI videos from text prompts using multiple provider gateways. Use when: (1) Generating videos from text descriptions, (2) Creating AI-generated video clips for content production, (3) Image-to-video generation with a reference image, (4) Choosing between video generation providers (VEO, Kling, Sora, Runway, Seedance, MiniMax). Supports two gateways: HeyGen API and fal.ai API.
+  Generate AI videos from text prompts using multiple provider gateways. Use when: (1) Generating videos from text descriptions, (2) Creating AI-generated video clips for content production, (3) Image-to-video generation with a reference image, (4) Choosing between video generation providers (VEO, Kling, Sora, Runway, Seedance, MiniMax, Wan). Supports three gateways: HeyGen API, fal.ai API, and Alibaba DashScope.
 allowed-tools: mcp__heygen__*
 metadata:
   openclaw:
@@ -9,18 +9,22 @@ metadata:
       env_any:
         - HEYGEN_API_KEY
         - FAL_KEY
+        - DASHSCOPE_API_KEY
 ---
 
 # Video Generation (Multi-Gateway)
 
-Generate AI videos from text prompts. Supports multiple providers via two API gateways:
+Generate AI videos from text prompts. Supports multiple providers via three API gateways:
 
 | Gateway | Env Variable | Providers | Tool |
 |---------|-------------|-----------|------|
 | **fal.ai** | `FAL_KEY` | Kling v3/v2.1, MiniMax, VEO | `kling_video`, `minimax_video`, `veo_video` |
 | **HeyGen** | `HEYGEN_API_KEY` | VEO 3.1, Kling Pro, Sora v2, Runway Gen-4, Seedance | `heygen_video` |
+| **Alibaba DashScope** | `DASHSCOPE_API_KEY` | Wan 2.7 / 2.6 / 2.5 (text-to-video AND image-to-video) | `wan_video_api` |
 
 **IMPORTANT:** Always use `video_selector` instead of calling provider tools directly. The selector handles availability checks, cost comparison, and automatic fallback.
+
+For the DashScope gateway (Wan T2V / I2V) see the dedicated `dashscope` Layer 3 skill — it covers auth, the async task pattern shared with `wan_image` / `qwen_image`, model tiers, and size/duration limits. The rest of this page describes the HeyGen and fal.ai gateways.
 
 ## Authentication
 

--- a/.agents/skills/dashscope/SKILL.md
+++ b/.agents/skills/dashscope/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: dashscope
+description: |
+  Alibaba DashScope (Bailian / Model Studio) API integration guide for the Wan and Qwen family of generation models. Use when working with: (1) `wan_image` text-to-image, (2) `qwen_image` text-to-image, (3) `wan_video_api` text-to-video or image-to-video (Wan 2.7 / 2.6 / 2.5), (4) `qwen_tts` text-to-speech including Chinese dialect voices. Covers auth, the async task pattern (POST + poll), the synchronous TTS pattern, and the shared helpers in `tools/_dashscope.py`.
+metadata:
+  openclaw:
+    requires:
+      env_any:
+        - DASHSCOPE_API_KEY
+        - ALIYUN_DASHSCOPE_API_KEY
+    primaryEnv: DASHSCOPE_API_KEY
+---
+
+# Alibaba DashScope (Bailian / Model Studio)
+
+DashScope is Alibaba's Model Studio API that serves the Wan and Qwen
+generation families — images, videos, and text-to-speech. A single API key
+unlocks all four OpenMontage tools built on it:
+
+| Tool | Capability | Operation pattern |
+|------|-----------|-------------------|
+| `wan_image` | `image_generation` | Async task (POST + poll) |
+| `qwen_image` | `image_generation` | Async task (POST + poll) |
+| `wan_video_api` | `video_generation` (text-to-video AND image-to-video) | Async task (POST + poll) |
+| `qwen_tts` | `tts` | **Synchronous** (POST → audio URL → download) |
+
+Do not duplicate HTTP plumbing. Always go through `tools/_dashscope.py`,
+which centralizes auth, headers, task submission, polling, and asset download.
+
+## Authentication
+
+Set either `DASHSCOPE_API_KEY` (canonical) or `ALIYUN_DASHSCOPE_API_KEY`
+(alias used by some Aliyun docs). Get one at
+<https://bailian.console.aliyun.com/?apiKey=1#/api-key>.
+
+```python
+from tools import _dashscope as dashscope
+api_key = dashscope.get_api_key()  # reads both env names
+```
+
+In OpenMontage the tools' `get_status()` already checks this; agents should
+go through the selector (`image_selector`, `video_selector`, `tts_selector`)
+rather than calling the DashScope tools directly.
+
+## Endpoints
+
+| Purpose | URL |
+|---------|-----|
+| Base | `https://dashscope.aliyuncs.com/api/v1` |
+| Text-to-image (Wan, Qwen-Image) | `/services/aigc/text2image/image-synthesis` |
+| Text-to-video (Wan T2V) | `/services/aigc/video-generation/video-synthesis` |
+| Image-to-video (Wan I2V) | `/services/aigc/video-generation/video-synthesis` with `operation` field |
+| TTS (Qwen-TTS) | `/services/aigc/multimodal-generation/generation` |
+| Task status | `/tasks/{task_id}` |
+
+## Async Task Pattern (images and videos)
+
+Image and video endpoints are **asynchronous**:
+
+1. POST with header `X-DashScope-Async: enable` → returns `task_id`.
+2. GET `/tasks/{task_id}` every 5s until `task_status` is terminal.
+3. Terminal success: `SUCCEEDED`. Terminal failure: `FAILED`, `CANCELED`, `UNKNOWN`.
+4. Success payload includes result URLs under `output.results[]` (images) or
+   `output.video_url` / `output.results[0].video_url` (videos).
+5. Download with a plain `GET` (no auth header needed for the signed URL).
+
+The helpers in `tools/_dashscope.py` implement all of this:
+
+```python
+from tools import _dashscope as dashscope
+
+task_id = dashscope.submit_async_task(
+    dashscope.TEXT_TO_IMAGE_ENDPOINT,
+    payload,
+    api_key,
+)
+output = dashscope.poll_task(task_id, api_key)           # raises on failure/timeout
+urls = dashscope.extract_result_urls(output, "url")       # "url" for images
+# urls = dashscope.extract_result_urls(output, "video_url")  # for videos
+dashscope.download_asset(urls[0], Path("out.png"))
+```
+
+Use `submit_async_task` + `poll_task` + `extract_result_urls` + `download_asset`.
+**Never reimplement the HTTP dance.**
+
+## Synchronous TTS Pattern (Qwen-TTS)
+
+Qwen-TTS does not use the async task pattern. The POST returns the audio
+URL in the first response body:
+
+```python
+import requests
+from tools import _dashscope as dashscope
+
+resp = requests.post(
+    f"{dashscope.DASHSCOPE_BASE_URL}/services/aigc/multimodal-generation/generation",
+    headers=dashscope.build_headers(api_key, async_task=False),   # no X-DashScope-Async
+    json={"model": "qwen-tts-latest", "input": {"text": "...", "voice": "Cherry"}},
+    timeout=120,
+)
+body = resp.json()
+# Top-level shape:    body["output"]["audio"]["url"]
+# Nested choices:     body["output"]["choices"][0]["message"]["content"][i]["audio"]["url"]
+```
+
+`QwenTTS._extract_audio_url(body)` handles both response shapes; reuse it when
+rolling anything custom.
+
+## Models
+
+### Wan-Image (`wan_image`)
+
+| Model | Tier | ~$/image |
+|-------|------|----------|
+| `wan2.7-image-pro` | pro | $0.06 |
+| `wan2.7-image` | standard (default) | $0.04 |
+| `wan2.2-t2i-plus` | plus | $0.03 |
+| `wan2.2-t2i-flash` | flash | $0.02 |
+
+Sizes use the DashScope `W*H` string (e.g. `1024*1024`, `1440*810`,
+`810*1440`, `1664*928`, `928*1664`). Not `{width, height}`, not a pixel list.
+Accepts `negative_prompt`, `seed`, `n` (1-4), `prompt_extend` (bool).
+
+### Qwen-Image (`qwen_image`)
+
+| Model | Tier | ~$/image | Notable |
+|-------|------|----------|---------|
+| `qwen-image-2.0-pro` | pro | $0.08 | |
+| `qwen-image-2.0` | standard (default) | $0.05 | |
+| `qwen-image-plus` | plus | $0.04 | |
+| `qwen-image` | base | $0.03 | |
+
+Strongest public model for rendering **legible Chinese characters inside an
+image** (posters, signage, overlays). Accepts the same parameters as Wan-Image
+plus first-class Chinese prompt support.
+
+### Wan-Video via API (`wan_video_api`)
+
+Text-to-video:
+
+| Model | Tier | ~$/clip | Max duration |
+|-------|------|---------|--------------|
+| `wan2.7-t2v` | pro (default) | $0.70 | 10s |
+| `wan2.5-t2v-plus` | plus | $0.50 | 10s |
+| `wan2.2-t2v-plus` | plus | $0.40 | 10s |
+
+Image-to-video (set `operation="image_to_video"` and pass `img_url` — the URL
+must be publicly reachable by DashScope's task workers; upload a local image
+to a public bucket or a signed URL beforehand):
+
+| Model | Tier | ~$/clip | Max duration |
+|-------|------|---------|--------------|
+| `wan2.7-i2v` | pro | $0.70 | 10s |
+| `wan2.5-i2v-plus` | plus | $0.50 | 10s |
+| `wan2.6-i2v-flash` | flash | $0.25 | 5s |
+
+Sizes: `1280*720`, `720*1280`, `960*960`, `1920*1080`, `1080*1920`. Audio is
+not generated — handle narration and music in the asset stage.
+
+### Qwen-TTS (`qwen_tts`)
+
+| Model | Notes |
+|-------|-------|
+| `qwen-tts-latest` | OpenMontage default; dialect voices require this. |
+| `qwen-tts` | Stable baseline. |
+| `qwen-tts-2025-05-22` | Pinned snapshot for reproducibility. |
+
+Voices:
+
+- Bilingual EN/ZH: `Cherry` (female, default), `Ethan` (male), `Chelsie` (female), `Serena` (female).
+- Chinese dialects (`qwen-tts-latest` only): `Dylan` (Beijing), `Sunny` (Sichuan), `Jada` (Shanghai).
+
+Pricing is per 1k characters of input (~$0.0014 / 1k chars) — the cheapest
+TTS provider in the OpenMontage stack.
+
+## Prompt Guidance
+
+- Both Chinese and English prompts work natively. **Do not pre-translate
+  Chinese briefs into English** — Wan and Qwen handle Chinese first-class.
+- Keep `prompt_extend=true` when you want DashScope to enrich short prompts.
+  Disable it (`prompt_extend=false`) when you need verbatim control.
+- For image-to-video: describe **motion only**. Do not re-describe what is
+  already in the reference image; identity and setting carry over from
+  `img_url`.
+- Follow the universal cinematography vocabulary from
+  `skills/creative/video-gen-prompting.md` — Wan responds well to the
+  standard shot / camera / lighting / style fields.
+
+## Common Pitfalls
+
+1. **Reimplementing HTTP / polling.** Always use `tools/_dashscope.py`.
+2. **Forgetting `X-DashScope-Async: enable`** on image/video POST — without
+   it you get a sync response that may time out.
+3. **Adding `X-DashScope-Async` to Qwen-TTS** — TTS is synchronous; setting
+   the header is harmless but misleading. Pass `async_task=False` to
+   `build_headers` for TTS.
+4. **Passing a local file path as `img_url`** for I2V. The URL must be
+   publicly fetchable; use the `image_path` alias only after uploading.
+5. **Pairing a dialect voice with a non-`latest` TTS model.** `Dylan`,
+   `Sunny`, and `Jada` require `qwen-tts-latest`. The tool will error before
+   calling the API.
+6. **Using `{width, height}` for size.** DashScope expects the `W*H` string.
+7. **Downloading audio/video with the DashScope `Authorization` header.**
+   The result URL is pre-signed; use `dashscope.download_asset(url, path)`
+   which omits the bearer token.
+
+## When to Prefer the DashScope Stack
+
+- The project brief is in **Chinese** (or mixes Chinese and English).
+- The deliverable requires **legible Chinese text inside images** — Qwen-Image is the strongest option.
+- The user wants to **consolidate on a single API key** across image + video + TTS.
+- The project needs **Chinese dialect narration** (Beijing / Sichuan / Shanghai).
+- A GPU-free cloud path is needed for Wan video generation (use `wan_video_api`, not the local `wan_video`).
+
+## References
+
+- Wan text-to-image: <https://help.aliyun.com/zh/model-studio/text-to-image>
+- Qwen-Image: <https://help.aliyun.com/zh/model-studio/qwen-image-api>
+- Wan text-to-video: <https://help.aliyun.com/zh/model-studio/text-to-video-api-reference>
+- Wan image-to-video: <https://help.aliyun.com/zh/model-studio/image-to-video-api-reference/>
+- Qwen-TTS: <https://help.aliyun.com/zh/model-studio/qwen-tts-api>
+- OpenMontage helpers: `tools/_dashscope.py`

--- a/.claude/skills/ai-video-gen/SKILL.md
+++ b/.claude/skills/ai-video-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-video-gen
 description: |
-  Generate AI videos from text prompts using multiple provider gateways. Use when: (1) Generating videos from text descriptions, (2) Creating AI-generated video clips for content production, (3) Image-to-video generation with a reference image, (4) Choosing between video generation providers (VEO, Kling, Sora, Runway, Seedance, MiniMax). Supports two gateways: HeyGen API and fal.ai API.
+  Generate AI videos from text prompts using multiple provider gateways. Use when: (1) Generating videos from text descriptions, (2) Creating AI-generated video clips for content production, (3) Image-to-video generation with a reference image, (4) Choosing between video generation providers (VEO, Kling, Sora, Runway, Seedance, MiniMax, Wan). Supports three gateways: HeyGen API, fal.ai API, and Alibaba DashScope.
 allowed-tools: mcp__heygen__*
 metadata:
   openclaw:
@@ -9,18 +9,22 @@ metadata:
       env_any:
         - HEYGEN_API_KEY
         - FAL_KEY
+        - DASHSCOPE_API_KEY
 ---
 
 # Video Generation (Multi-Gateway)
 
-Generate AI videos from text prompts. Supports multiple providers via two API gateways:
+Generate AI videos from text prompts. Supports multiple providers via three API gateways:
 
 | Gateway | Env Variable | Providers | Tool |
 |---------|-------------|-----------|------|
 | **fal.ai** | `FAL_KEY` | Kling v3/v2.1, MiniMax, VEO | `kling_video`, `minimax_video`, `veo_video` |
 | **HeyGen** | `HEYGEN_API_KEY` | VEO 3.1, Kling Pro, Sora v2, Runway Gen-4, Seedance | `heygen_video` |
+| **Alibaba DashScope** | `DASHSCOPE_API_KEY` | Wan 2.7 / 2.6 / 2.5 (text-to-video AND image-to-video) | `wan_video_api` |
 
 **IMPORTANT:** Always use `video_selector` instead of calling provider tools directly. The selector handles availability checks, cost comparison, and automatic fallback.
+
+For the DashScope gateway (Wan T2V / I2V) see the dedicated `dashscope` Layer 3 skill — it covers auth, the async task pattern shared with `wan_image` / `qwen_image`, model tiers, and size/duration limits. The rest of this page describes the HeyGen and fal.ai gateways.
 
 ## Authentication
 

--- a/.claude/skills/dashscope/SKILL.md
+++ b/.claude/skills/dashscope/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: dashscope
+description: |
+  Alibaba DashScope (Bailian / Model Studio) API integration guide for the Wan and Qwen family of generation models. Use when working with: (1) `wan_image` text-to-image, (2) `qwen_image` text-to-image, (3) `wan_video_api` text-to-video or image-to-video (Wan 2.7 / 2.6 / 2.5), (4) `qwen_tts` text-to-speech including Chinese dialect voices. Covers auth, the async task pattern (POST + poll), the synchronous TTS pattern, and the shared helpers in `tools/_dashscope.py`.
+metadata:
+  openclaw:
+    requires:
+      env_any:
+        - DASHSCOPE_API_KEY
+        - ALIYUN_DASHSCOPE_API_KEY
+    primaryEnv: DASHSCOPE_API_KEY
+---
+
+# Alibaba DashScope (Bailian / Model Studio)
+
+DashScope is Alibaba's Model Studio API that serves the Wan and Qwen
+generation families — images, videos, and text-to-speech. A single API key
+unlocks all four OpenMontage tools built on it:
+
+| Tool | Capability | Operation pattern |
+|------|-----------|-------------------|
+| `wan_image` | `image_generation` | Async task (POST + poll) |
+| `qwen_image` | `image_generation` | Async task (POST + poll) |
+| `wan_video_api` | `video_generation` (text-to-video AND image-to-video) | Async task (POST + poll) |
+| `qwen_tts` | `tts` | **Synchronous** (POST → audio URL → download) |
+
+Do not duplicate HTTP plumbing. Always go through `tools/_dashscope.py`,
+which centralizes auth, headers, task submission, polling, and asset download.
+
+## Authentication
+
+Set either `DASHSCOPE_API_KEY` (canonical) or `ALIYUN_DASHSCOPE_API_KEY`
+(alias used by some Aliyun docs). Get one at
+<https://bailian.console.aliyun.com/?apiKey=1#/api-key>.
+
+```python
+from tools import _dashscope as dashscope
+api_key = dashscope.get_api_key()  # reads both env names
+```
+
+In OpenMontage the tools' `get_status()` already checks this; agents should
+go through the selector (`image_selector`, `video_selector`, `tts_selector`)
+rather than calling the DashScope tools directly.
+
+## Endpoints
+
+| Purpose | URL |
+|---------|-----|
+| Base | `https://dashscope.aliyuncs.com/api/v1` |
+| Text-to-image (Wan, Qwen-Image) | `/services/aigc/text2image/image-synthesis` |
+| Text-to-video (Wan T2V) | `/services/aigc/video-generation/video-synthesis` |
+| Image-to-video (Wan I2V) | `/services/aigc/video-generation/video-synthesis` with `operation` field |
+| TTS (Qwen-TTS) | `/services/aigc/multimodal-generation/generation` |
+| Task status | `/tasks/{task_id}` |
+
+## Async Task Pattern (images and videos)
+
+Image and video endpoints are **asynchronous**:
+
+1. POST with header `X-DashScope-Async: enable` → returns `task_id`.
+2. GET `/tasks/{task_id}` every 5s until `task_status` is terminal.
+3. Terminal success: `SUCCEEDED`. Terminal failure: `FAILED`, `CANCELED`, `UNKNOWN`.
+4. Success payload includes result URLs under `output.results[]` (images) or
+   `output.video_url` / `output.results[0].video_url` (videos).
+5. Download with a plain `GET` (no auth header needed for the signed URL).
+
+The helpers in `tools/_dashscope.py` implement all of this:
+
+```python
+from tools import _dashscope as dashscope
+
+task_id = dashscope.submit_async_task(
+    dashscope.TEXT_TO_IMAGE_ENDPOINT,
+    payload,
+    api_key,
+)
+output = dashscope.poll_task(task_id, api_key)           # raises on failure/timeout
+urls = dashscope.extract_result_urls(output, "url")       # "url" for images
+# urls = dashscope.extract_result_urls(output, "video_url")  # for videos
+dashscope.download_asset(urls[0], Path("out.png"))
+```
+
+Use `submit_async_task` + `poll_task` + `extract_result_urls` + `download_asset`.
+**Never reimplement the HTTP dance.**
+
+## Synchronous TTS Pattern (Qwen-TTS)
+
+Qwen-TTS does not use the async task pattern. The POST returns the audio
+URL in the first response body:
+
+```python
+import requests
+from tools import _dashscope as dashscope
+
+resp = requests.post(
+    f"{dashscope.DASHSCOPE_BASE_URL}/services/aigc/multimodal-generation/generation",
+    headers=dashscope.build_headers(api_key, async_task=False),   # no X-DashScope-Async
+    json={"model": "qwen-tts-latest", "input": {"text": "...", "voice": "Cherry"}},
+    timeout=120,
+)
+body = resp.json()
+# Top-level shape:    body["output"]["audio"]["url"]
+# Nested choices:     body["output"]["choices"][0]["message"]["content"][i]["audio"]["url"]
+```
+
+`QwenTTS._extract_audio_url(body)` handles both response shapes; reuse it when
+rolling anything custom.
+
+## Models
+
+### Wan-Image (`wan_image`)
+
+| Model | Tier | ~$/image |
+|-------|------|----------|
+| `wan2.7-image-pro` | pro | $0.06 |
+| `wan2.7-image` | standard (default) | $0.04 |
+| `wan2.2-t2i-plus` | plus | $0.03 |
+| `wan2.2-t2i-flash` | flash | $0.02 |
+
+Sizes use the DashScope `W*H` string (e.g. `1024*1024`, `1440*810`,
+`810*1440`, `1664*928`, `928*1664`). Not `{width, height}`, not a pixel list.
+Accepts `negative_prompt`, `seed`, `n` (1-4), `prompt_extend` (bool).
+
+### Qwen-Image (`qwen_image`)
+
+| Model | Tier | ~$/image | Notable |
+|-------|------|----------|---------|
+| `qwen-image-2.0-pro` | pro | $0.08 | |
+| `qwen-image-2.0` | standard (default) | $0.05 | |
+| `qwen-image-plus` | plus | $0.04 | |
+| `qwen-image` | base | $0.03 | |
+
+Strongest public model for rendering **legible Chinese characters inside an
+image** (posters, signage, overlays). Accepts the same parameters as Wan-Image
+plus first-class Chinese prompt support.
+
+### Wan-Video via API (`wan_video_api`)
+
+Text-to-video:
+
+| Model | Tier | ~$/clip | Max duration |
+|-------|------|---------|--------------|
+| `wan2.7-t2v` | pro (default) | $0.70 | 10s |
+| `wan2.5-t2v-plus` | plus | $0.50 | 10s |
+| `wan2.2-t2v-plus` | plus | $0.40 | 10s |
+
+Image-to-video (set `operation="image_to_video"` and pass `img_url` — the URL
+must be publicly reachable by DashScope's task workers; upload a local image
+to a public bucket or a signed URL beforehand):
+
+| Model | Tier | ~$/clip | Max duration |
+|-------|------|---------|--------------|
+| `wan2.7-i2v` | pro | $0.70 | 10s |
+| `wan2.5-i2v-plus` | plus | $0.50 | 10s |
+| `wan2.6-i2v-flash` | flash | $0.25 | 5s |
+
+Sizes: `1280*720`, `720*1280`, `960*960`, `1920*1080`, `1080*1920`. Audio is
+not generated — handle narration and music in the asset stage.
+
+### Qwen-TTS (`qwen_tts`)
+
+| Model | Notes |
+|-------|-------|
+| `qwen-tts-latest` | OpenMontage default; dialect voices require this. |
+| `qwen-tts` | Stable baseline. |
+| `qwen-tts-2025-05-22` | Pinned snapshot for reproducibility. |
+
+Voices:
+
+- Bilingual EN/ZH: `Cherry` (female, default), `Ethan` (male), `Chelsie` (female), `Serena` (female).
+- Chinese dialects (`qwen-tts-latest` only): `Dylan` (Beijing), `Sunny` (Sichuan), `Jada` (Shanghai).
+
+Pricing is per 1k characters of input (~$0.0014 / 1k chars) — the cheapest
+TTS provider in the OpenMontage stack.
+
+## Prompt Guidance
+
+- Both Chinese and English prompts work natively. **Do not pre-translate
+  Chinese briefs into English** — Wan and Qwen handle Chinese first-class.
+- Keep `prompt_extend=true` when you want DashScope to enrich short prompts.
+  Disable it (`prompt_extend=false`) when you need verbatim control.
+- For image-to-video: describe **motion only**. Do not re-describe what is
+  already in the reference image; identity and setting carry over from
+  `img_url`.
+- Follow the universal cinematography vocabulary from
+  `skills/creative/video-gen-prompting.md` — Wan responds well to the
+  standard shot / camera / lighting / style fields.
+
+## Common Pitfalls
+
+1. **Reimplementing HTTP / polling.** Always use `tools/_dashscope.py`.
+2. **Forgetting `X-DashScope-Async: enable`** on image/video POST — without
+   it you get a sync response that may time out.
+3. **Adding `X-DashScope-Async` to Qwen-TTS** — TTS is synchronous; setting
+   the header is harmless but misleading. Pass `async_task=False` to
+   `build_headers` for TTS.
+4. **Passing a local file path as `img_url`** for I2V. The URL must be
+   publicly fetchable; use the `image_path` alias only after uploading.
+5. **Pairing a dialect voice with a non-`latest` TTS model.** `Dylan`,
+   `Sunny`, and `Jada` require `qwen-tts-latest`. The tool will error before
+   calling the API.
+6. **Using `{width, height}` for size.** DashScope expects the `W*H` string.
+7. **Downloading audio/video with the DashScope `Authorization` header.**
+   The result URL is pre-signed; use `dashscope.download_asset(url, path)`
+   which omits the bearer token.
+
+## When to Prefer the DashScope Stack
+
+- The project brief is in **Chinese** (or mixes Chinese and English).
+- The deliverable requires **legible Chinese text inside images** — Qwen-Image is the strongest option.
+- The user wants to **consolidate on a single API key** across image + video + TTS.
+- The project needs **Chinese dialect narration** (Beijing / Sichuan / Shanghai).
+- A GPU-free cloud path is needed for Wan video generation (use `wan_video_api`, not the local `wan_video`).
+
+## References
+
+- Wan text-to-image: <https://help.aliyun.com/zh/model-studio/text-to-image>
+- Qwen-Image: <https://help.aliyun.com/zh/model-studio/qwen-image-api>
+- Wan text-to-video: <https://help.aliyun.com/zh/model-studio/text-to-video-api-reference>
+- Wan image-to-video: <https://help.aliyun.com/zh/model-studio/image-to-video-api-reference/>
+- Qwen-TTS: <https://help.aliyun.com/zh/model-studio/qwen-tts-api>
+- OpenMontage helpers: `tools/_dashscope.py`

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -91,7 +91,7 @@ Key capability families to look for in the output:
 | Enhancement Strategy | `creative/enhancement-strategy.md` | Overlay placement and density | `ffmpeg` |
 | Data Visualization | `creative/data-visualization.md` | Chart type selection, animation, label placement | `d3-viz`, `remotion-best-practices` |
 | Video Stitching | `creative/video-stitching.md` | Multi-clip assembly, AI clip chaining, spatial composition | `ffmpeg`, `video_toolkit` |
-| Video Gen Prompting | `creative/video-gen-prompting.md` | Universal video generation prompt vocabulary | `ai-video-gen`, `ltx2`, `create-video` |
+| Video Gen Prompting | `creative/video-gen-prompting.md` | Universal video generation prompt vocabulary | `ai-video-gen`, `ltx2`, `create-video`, `dashscope` |
 | â†³ Grok Prompting | `creative/prompting/grok-prompting.md` | Grok image/video prompting, edit flows, reference-image video | `grok-media` |
 | â†³ Sora Prompting | `creative/prompting/sora-prompting.md` | Sora 2 structured template, advanced fields | `ai-video-gen` |
 | â†³ VEO Prompting | `creative/prompting/veo-prompting.md` | VEO 3.1 14-component structure, art movements | `ai-video-gen` |
@@ -102,7 +102,8 @@ Key capability families to look for in the output:
 | Typography | `creative/typography.md` | Font selection, text sizing, safe zones, caption styling | â€" |
 | ManimCE Usage | `creative/manim-usage.md` | Scene composition, animation timing, color usage | `manimce-best-practices` |
 | Image Gen Usage | `creative/image-gen-usage.md` | Prompt consistency, hero reference, batch strategy | `flux-best-practices`, `bfl-api` |
-| Image Provider Usage | `creative/image-provider-usage.md` | Provider selection (FLUX/Grok/OpenAI/Recraft/stock), cost-quality tradeoffs | `flux-best-practices`, `bfl-api`, `grok-media` |
+| Image Provider Usage | `creative/image-provider-usage.md` | Provider selection (FLUX/Grok/OpenAI/Recraft/Qwen/Wan/stock), cost-quality tradeoffs | `flux-best-practices`, `bfl-api`, `grok-media`, `dashscope` |
+| TTS Provider Usage | `creative/tts-provider-usage.md` | Provider selection (ElevenLabs/OpenAI/Google/Qwen/Piper), language and dialect routing | `elevenlabs`, `text-to-speech`, `dashscope` |
 | B-Roll Planning | `creative/broll-planning.md` | Stock vs. generated decision, query construction, footage evaluation | — |
 | Stock Sourcing Usage | `creative/stock-sourcing-usage.md` | Pexels/Pixabay usage, parameters, licensing, integration | — |
 | Scene Detect Usage | `creative/scene-detect-usage.md` | Threshold tuning, algorithm selection, content presets | â€" |
@@ -299,7 +300,8 @@ Claude Code accesses them via symlinks in `.claude/skills/`.
 | **Video Composition** | `remotion-best-practices`, `remotion` | `remotion-dev/skills`, `digitalsamba/claude-code-video-toolkit` |
 | **Video Processing** | `ffmpeg`, `video_toolkit` | `digitalsamba/claude-code-video-toolkit` |
 | **TTS & Audio** | `text-to-speech`, `speech-to-text`, `music`, `sound-effects`, `elevenlabs`, `agents`, `setup-api-key` | `elevenlabs/skills`, `digitalsamba/claude-code-video-toolkit` |
-| **Image Generation** | `flux-best-practices`, `bfl-api`, `grok-media` | `black-forest-labs/skills`, local OpenMontage skill |
+| **Image Generation** | `flux-best-practices`, `bfl-api`, `grok-media`, `dashscope` | `black-forest-labs/skills`, local OpenMontage skill |
+| **Alibaba DashScope (Wan / Qwen)** | `dashscope` | local OpenMontage skill — covers `wan_image`, `qwen_image`, `wan_video_api` (T2V+I2V), `qwen_tts` |
 | **Math Animation** | `manimce-best-practices`, `manimgl-best-practices`, `manim-composer` | `adithya-s-k/manim_skill` |
 | **3D Graphics** | `threejs-animation`, `threejs-fundamentals`, `threejs-geometry`, `threejs-interaction`, `threejs-lighting`, `threejs-loaders`, `threejs-materials`, `threejs-postprocessing`, `threejs-shaders`, `threejs-textures` | `cloudai-x/threejs-skills` |
 | **Diagrams** | `beautiful-mermaid`, `d3-viz` | `intellectronica/agent-skills`, `davila7/claude-code-templates` |

--- a/skills/creative/image-provider-usage.md
+++ b/skills/creative/image-provider-usage.md
@@ -2,6 +2,8 @@
 
 > How to choose between image generation and stock providers, and how to use each effectively.
 > Supplements the existing `image-gen-usage.md` (which covers FLUX prompting in depth).
+> Layer 3: `.agents/skills/flux-best-practices`, `.agents/skills/bfl-api`,
+> `.agents/skills/grok-media`, `.agents/skills/dashscope` (for Qwen-Image / Wan-Image).
 
 ## Provider Landscape
 
@@ -13,6 +15,8 @@
 | `grok_image` | Grok Imagine Image (xAI) | $0.02/output + $0.002/input edit image | ~5-15s | Image edits, style transfer, multi-image compositing |
 | `openai_image` | GPT Image 1 (OpenAI) | ~$0.01-0.17 | ~5-15s | Complex instructions, text in images, multi-element |
 | `recraft_image` | Recraft V4 via fal.ai | ~$0.04-0.25 | ~5-10s | Logos, SVG vectors, brand assets, text rendering (see caveat below) |
+| `qwen_image` | Qwen-Image 2.0 via Alibaba DashScope | $0.03-0.08 | ~20-30s | Chinese/English prompts, legible text rendered inside images, posters, bilingual illustrations |
+| `wan_image` | Wan 2.7 / 2.2 via Alibaba DashScope | $0.02-0.06 | ~20-30s | Photorealism and illustration with strong Chinese-language prompting, Wan/Qwen stack parity |
 | `local_diffusion` | Stable Diffusion (local) | Free | ~30s+ | Offline, privacy, free |
 | `image_gen` | Multi (legacy, deprecated) | Varies | Varies | **Deprecated** — use `image_selector` or per-provider tools |
 
@@ -39,7 +43,10 @@
 | **Style transfer / repaint of an existing image** | `grok_image` | Native edit flow, strong promptable transforms | `openai_image` |
 | **Multi-image merge / composite** | `grok_image` | Can combine multiple source images into one scene | `openai_image` |
 | **Logo or brand asset** | `recraft_image` | SVG support, text accuracy | `openai_image` |
-| **Image with text/labels** | `openai_image` | Best text rendering (GPT Image 1) | `recraft_image` |
+| **Image with text/labels** | `openai_image` | Best text rendering (GPT Image 1) | `qwen_image` → `recraft_image` |
+| **Chinese text inside the image** | `qwen_image` | Qwen is the strongest at legible Chinese characters | `openai_image` |
+| **Chinese / bilingual prompts** | `qwen_image` or `wan_image` | Native Chinese prompting via Alibaba Model Studio | `flux_image` |
+| **Alibaba Model Studio pipelines** | `wan_image` | Keeps image + video stack on Wan 2.7 | `qwen_image` |
 | **Complex multi-element composition** | `openai_image` | Best instruction following | `flux_image` |
 | **Hero image (key visual)** | `flux_image` | Highest visual quality | `openai_image` |
 | **Thumbnail** | `flux_image` or `recraft_image` | Needs to be eye-catching | — |
@@ -51,6 +58,20 @@
 ### Recraft V4 via fal.ai
 - **`style` parameter causes 422 errors** (as of 2026-04). The `style` enum values (`digital_illustration`, `realistic_image`, etc.) are rejected by fal.ai's Recraft V4 endpoint. **Workaround:** encode style direction in the prompt text instead (e.g. "digital illustration of a tooth cross-section" rather than `style="digital_illustration"`). The `image_size` and `colors` parameters work fine.
 - **Text rendering is unreliable for exact business names.** Recraft (like all AI image models) may hallucinate wrong text. For any scene where text must be verbatim (CTA screens, business names, phone numbers), use Remotion `text_card` instead of generating an image with text.
+
+### Qwen-Image via Alibaba DashScope (`qwen_image`)
+- **Models:** `qwen-image-2.0-pro` (~$0.08), `qwen-image-2.0` (~$0.05, default), `qwen-image-plus` (~$0.04), `qwen-image` (~$0.03).
+- **Sizes:** use the DashScope `W*H` format (e.g. `1024*1024`, `1664*928`, `928*1664`). Not pixels-list — literally `width*height` with a `*`.
+- **Chinese in images:** Qwen is the strongest mainstream model for rendering legible Chinese characters inside an image. Prefer it over FLUX or DALL-E when the brief requires Chinese signage, posters, or overlays.
+- **Async API:** submission returns a `task_id`; the tool polls for you. Expect 20-30s latency.
+- **Auth:** set `DASHSCOPE_API_KEY` (alias: `ALIYUN_DASHSCOPE_API_KEY`).
+
+### Wan-Image via Alibaba DashScope (`wan_image`)
+- **Models:** `wan2.7-image-pro` (~$0.06), `wan2.7-image` (~$0.04, default), `wan2.2-t2i-plus` (~$0.03), `wan2.2-t2i-flash` (~$0.02).
+- **Sizes:** DashScope `W*H` format including widescreen `1440*810` and portrait `810*1440` for video frames.
+- **Best for** photoreal and illustrative images when the pipeline is already using Wan 2.7 video; keeps the image+video stack on one provider.
+- **Chinese prompts** work natively and often better than English translations.
+- **Auth:** set `DASHSCOPE_API_KEY` (shared with `qwen_image`, `qwen_tts`, and `wan_video_api`).
 
 ## Cost-Quality Tradeoff
 
@@ -67,6 +88,12 @@ PRODUCTION PATH: Standard
 ├── All generated: flux_image ($0.03/img)
 ├── B-roll stills: pexels_image ($0.00)
 └── Total for 10 images: ~$0.25
+
+PRODUCTION PATH: Alibaba Model Studio (Chinese-native or DashScope-only)
+├── Hero + supporting visuals: wan_image wan2.7-image ($0.04/img)
+├── Text-inside-image scenes: qwen_image qwen-image-2.0 ($0.05/img)
+├── B-roll stills: pexels_image ($0.00)
+└── Total for 10 images: ~$0.30 (single API key, pairs with wan_video_api + qwen_tts)
 
 PRODUCTION PATH: Budget
 ├── All stock: pexels_image + pixabay_image ($0.00)

--- a/skills/creative/tts-provider-usage.md
+++ b/skills/creative/tts-provider-usage.md
@@ -1,0 +1,157 @@
+# TTS Provider Usage for OpenMontage
+
+> How to choose among text-to-speech providers, and how to use each effectively.
+> Complements `lip-sync-usage.md`, `talking-head-gen-usage.md`, and `sound-design.md`.
+> Layer 3: `.agents/skills/elevenlabs`, `.agents/skills/text-to-speech`,
+> `.agents/skills/dashscope` (for Qwen-TTS).
+
+## Provider Landscape
+
+All TTS tools live under `tools/audio/` and register with `capability="tts"`.
+The `tts_selector` auto-discovers every provider in the registry — adding a
+new provider tool is enough; no selector code changes needed.
+
+| Tool | Provider | Runtime | Cost | Best For |
+|------|----------|---------|------|----------|
+| `elevenlabs_tts` | ElevenLabs | API | ~$0.30 / 1k chars | Highest-quality expressive English narration, voice cloning, spokesperson videos |
+| `openai_tts` | OpenAI (`gpt-4o-mini-tts`) | API | ~$0.015 / 1k chars | Cheap workhorse for English narration, delivery `instructions` parameter |
+| `google_tts` | Google Cloud TTS | API | ~$0.004-$0.030 / 1k chars | Localization (700+ voices, 50+ languages), SSML support, Chirp 3 HD |
+| `qwen_tts` | Qwen-TTS via Alibaba DashScope | API | ~$0.0014 / 1k chars | Native Chinese narration, Chinese dialect voices (Beijing, Sichuan, Shanghai), bilingual EN/ZH |
+| `piper_tts` | Piper (local) | LOCAL | Free | Offline / privacy-sensitive workflows, no API key |
+
+### Selector
+
+| Tool | Purpose |
+|------|---------|
+| `tts_selector` | Routes to the best available TTS provider based on preference, availability, and scored ranking |
+
+## Provider Selection by Scene Type
+
+| Brief | Primary | Why | Fallback |
+|-------|---------|-----|----------|
+| **English narration, production quality** | `elevenlabs_tts` | Most expressive English voices, clone support | `openai_tts` → `google_tts` |
+| **Cheap English narration at scale** | `openai_tts` | ~20x cheaper than ElevenLabs, still natural | `google_tts` |
+| **Chinese narration (Mandarin)** | `qwen_tts` | Native Mandarin prosody, bilingual EN/ZH voices | `google_tts` (Cmn-CN voices) |
+| **Chinese dialect narration** (Beijing / Sichuan / Shanghai) | `qwen_tts` with `qwen-tts-latest` | Dedicated dialect voices (Dylan / Sunny / Jada) | None in the registry — plan fallback to standard Mandarin |
+| **Localization / many languages** | `google_tts` | 700+ voices across 50+ languages, Chirp 3 HD | `elevenlabs_tts` multilingual |
+| **SSML control** (pronunciations, breaks) | `google_tts` | First-class SSML support | `elevenlabs_tts` |
+| **Voice cloning** (use an uploaded voice) | `elevenlabs_tts` | Only provider with cloning | — |
+| **Offline / air-gapped** | `piper_tts` | No network, no API key | — |
+| **Alibaba Model Studio pipelines** | `qwen_tts` | Shares `DASHSCOPE_API_KEY` with `wan_image` / `qwen_image` / `wan_video_api` | `google_tts` |
+
+## Provider-Specific Notes
+
+### ElevenLabs (`elevenlabs_tts`)
+- **Env var:** `ELEVENLABS_API_KEY`
+- Default model `eleven_multilingual_v2`. Tune `stability` (lower = more expressive) and `style` (higher = more exaggeration).
+- Formats: `mp3_44100_128` (default), `mp3_44100_192`, `pcm_16000`, `pcm_24000`.
+- Best combined with the `.agents/skills/elevenlabs` and `.agents/skills/text-to-speech` Layer 3 skills.
+
+### OpenAI (`openai_tts`)
+- **Env var:** `OPENAI_API_KEY`
+- Default model `gpt-4o-mini-tts`. Supports an `instructions` field to shape delivery ("speak warmly, like a documentary narrator").
+- Voices: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer` (and newer named voices via the API).
+- Good default for cost-sensitive production; fallback when ElevenLabs is unavailable.
+
+### Google Cloud TTS (`google_tts`)
+- **Env vars:** `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) **or** `GOOGLE_APPLICATION_CREDENTIALS`.
+- Voice tiers (most expressive first): Chirp 3 HD → Studio → Neural2 → WaveNet → Standard.
+- Chirp 3 HD and Journey voices route through the `v1beta1` endpoint automatically.
+- Supports `speakingRate`, `pitch`, and SSML input.
+
+### Qwen-TTS via Alibaba DashScope (`qwen_tts`)
+- **Env vars:** `DASHSCOPE_API_KEY` (alias: `ALIYUN_DASHSCOPE_API_KEY`). Shared with `qwen_image`, `wan_image`, and `wan_video_api`.
+- **Models:**
+  - `qwen-tts` — stable.
+  - `qwen-tts-latest` (default in OpenMontage) — latest features including Chinese dialect voices.
+  - `qwen-tts-2025-05-22` — pinned snapshot for reproducibility.
+- **Voices:**
+  - Bilingual EN/ZH: `Cherry` (female, default), `Ethan` (male), `Chelsie` (female), `Serena` (female).
+  - Chinese dialects (require `qwen-tts-latest`): `Dylan` (Beijing Mandarin), `Sunny` (Sichuan Mandarin), `Jada` (Shanghainese).
+- **Protocol:** synchronous — the API returns `output.audio.url` on the first POST; the tool downloads the audio for you. No async polling, unlike `qwen_image` / `wan_video_api`.
+- **Best for:** Chinese-language narration, bilingual content, and any pipeline already on the Alibaba Model Studio stack where consolidating on one API key matters.
+
+### Piper (`piper_tts`)
+- **Runtime:** local (no API key). Requires the `piper` CLI and a downloaded voice model.
+- **Install:** `pip install piper-tts` + `piper --download-dir ~/.piper/models --model en_US-lessac-medium`.
+- Deterministic output given the same text + model + seed.
+
+## Using the TTS Selector
+
+For most cases, call `tts_selector` and let it route:
+
+```python
+result = tts_selector.execute({
+    "text": "Welcome to the OpenMontage production walkthrough.",
+    "preferred_provider": "auto",  # or "elevenlabs", "qwen", "google_tts", "openai", "piper"
+    "output_path": "projects/<slug>/assets/audio/narration-01.mp3",
+})
+```
+
+Restrict the pool when you need to stay inside a particular stack:
+
+```python
+# Alibaba Model Studio only — pairs with wan_video_api / qwen_image
+result = tts_selector.execute({
+    "text": "欢迎来到 OpenMontage 演示。",
+    "voice": "Cherry",
+    "allowed_providers": ["qwen"],
+    "output_path": "projects/<slug>/assets/audio/narration-01.mp3",
+})
+
+# Offline / free only
+result = tts_selector.execute({
+    "text": "Offline narration test.",
+    "allowed_providers": ["piper"],
+    "output_path": "projects/<slug>/assets/audio/narration-01.wav",
+})
+```
+
+Use `operation="rank"` to preview provider scoring without generating audio.
+
+## Cost-Quality Tradeoff
+
+```
+PRODUCTION PATH: Premium (English)
+├── All narration: elevenlabs_tts (~$0.30 / 1k chars)
+└── 2k-char script: ~$0.60
+
+PRODUCTION PATH: Standard (English)
+├── All narration: openai_tts (~$0.015 / 1k chars)
+└── 2k-char script: ~$0.03
+
+PRODUCTION PATH: Localization
+├── Any language: google_tts (Chirp 3 HD)
+└── 2k-char script: ~$0.06
+
+PRODUCTION PATH: Alibaba Model Studio (Chinese or bilingual)
+├── All narration: qwen_tts qwen-tts-latest (~$0.0014 / 1k chars)
+├── 2k-char script: ~$0.003
+└── Shares DASHSCOPE_API_KEY with qwen_image + wan_image + wan_video_api
+
+PRODUCTION PATH: Offline
+├── All narration: piper_tts (free, local)
+└── 2k-char script: $0.00
+```
+
+## Output Consistency
+
+When a project uses several TTS providers (e.g. Qwen for Mandarin segments
+and ElevenLabs for English segments), normalize loudness in the asset stage
+using `audio_mixer` / the LUFS targets defined in `sound-design.md`. Do not
+ship raw provider output — it will not match across vendors.
+
+## Common Pitfalls
+
+1. **Cross-provider loudness drift.** Every provider masters at a different
+   target. Always run the `audio_enhance` / `audio_mixer` normalize step.
+2. **Ignoring dialect requirements.** `qwen_tts` dialect voices (Dylan / Sunny / Jada)
+   only work with `qwen-tts-latest`. The selector will surface the error if you
+   pair a dialect voice with a non-latest model.
+3. **Assuming Chinese quality from English-first providers.** ElevenLabs and
+   OpenAI can say Mandarin, but prosody is weaker than Qwen-TTS or Google
+   Chirp 3 HD Cmn-CN voices. Prefer native providers for native languages.
+4. **Hardcoding a provider.** Always go through `tts_selector` so a missing
+   API key falls back instead of crashing the pipeline.
+5. **Skipping SSML** when breaks, emphasis, or pronunciations matter. Use
+   `google_tts` or `elevenlabs_tts` with SSML for production-grade reads.

--- a/skills/creative/video-gen-prompting.md
+++ b/skills/creative/video-gen-prompting.md
@@ -3,10 +3,15 @@
 ## When to Use
 
 When writing prompts for the video generation family (`video_selector`, `heygen_video`,
-`wan_video`, `hunyuan_video`, `ltx_video_local`, `ltx_video_modal`, `cogvideo_video`).
+`wan_video`, `wan_video_api`, `hunyuan_video`, `ltx_video_local`, `ltx_video_modal`,
+`cogvideo_video`).
 This skill covers the universal prompt vocabulary that works across all video generation models.
 
 For model-specific tips, see the linked guides below.
+
+Layer 3: `.agents/skills/ai-video-gen` (HeyGen/fal.ai gateways),
+`.agents/skills/ltx2` (LTX-2), `.agents/skills/dashscope` (Wan T2V / I2V via
+Alibaba DashScope).
 
 ## Model-Specific Guides
 
@@ -19,7 +24,8 @@ For model-specific tips, see the linked guides below.
 | **HunyuanVideo 1.5** | [Tencent Prompt Handbook](https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5/blob/main/assets/HunyuanVideo_1_5_Prompt_Handbook_EN.md) | Formula: Subject + Motion + Scene + [Shot] + [Camera] + [Lighting] + [Style] + [Atmosphere]. |
 | **Runway Gen-4** | [Runway Prompting Guide](https://help.runwayml.com/hc/en-us/articles/39789879462419-Gen-4-Video-Prompting-Guide) | "Focus on motion, not appearance." One scene per clip. Simplicity wins. |
 | **Kling 2.6** | [Kling Prompt Guide](https://fal.ai/learn/devs/kling-2-6-pro-prompt-guide) | 4-part structure. Supports `++emphasis++` syntax for key elements. |
-| **Wan 2.1 / CogVideoX** | Use this generic guide | No official prompt guide. Standard cinematographic vocabulary works well. |
+| **Wan 2.7 / 2.6 / 2.5 (DashScope API)** | [Aliyun Text-to-Video](https://help.aliyun.com/zh/model-studio/text-to-video-api-reference) · [Image-to-Video](https://help.aliyun.com/zh/model-studio/image-to-video-api-reference/) | Use `wan_video_api` for cloud T2V/I2V. Handles Chinese and English prompts natively; set `operation="image_to_video"` with `img_url` for I2V. Max 10s clips. |
+| **Wan 2.1 / CogVideoX (local)** | Use this generic guide | No official prompt guide. Standard cinematographic vocabulary works well. Local GPU path via `wan_video` / `cogvideo_video`. |
 
 ## Universal Prompt Formula
 
@@ -177,6 +183,71 @@ Put dialogue in quotation marks: `Character says: "Hello world."`
 4. **For consistency across clips** — repeat the same style/lighting/grade description.
 5. **Use seed values** — when you find a good result, save the seed for variations.
 6. **For Grok reference-image video** — assign each source image a clear role in the prompt using `<IMAGE_1>`, `<IMAGE_2>`, etc.
+
+## Wan Video via Alibaba DashScope (`wan_video_api`)
+
+Cloud path for the Wan video family that does not require a local GPU.
+Use when the project is already on the Alibaba Model Studio stack (paired
+with `qwen_image` / `wan_image` / `qwen_tts`) or when GPU is unavailable.
+
+### Models
+
+**Text-to-video:**
+
+| Model | Tier | ~Cost / clip | Max duration |
+|-------|------|-------------|--------------|
+| `wan2.7-t2v` | pro | ~$0.70 | 10s |
+| `wan2.5-t2v-plus` | plus | ~$0.50 | 10s |
+| `wan2.2-t2v-plus` | plus | ~$0.40 | 10s |
+
+**Image-to-video** (set `operation="image_to_video"` and pass `img_url`):
+
+| Model | Tier | ~Cost / clip | Max duration |
+|-------|------|-------------|--------------|
+| `wan2.7-i2v` | pro | ~$0.70 | 10s |
+| `wan2.5-i2v-plus` | plus | ~$0.50 | 10s |
+| `wan2.6-i2v-flash` | flash | ~$0.25 | 5s |
+
+Supported sizes: `1280*720`, `720*1280`, `960*960`, `1920*1080`, `1080*1920`
+(DashScope `W*H` string format, not a pixel list).
+
+### When to use T2V vs I2V
+
+- **T2V (`wan2.7-t2v`):** pure text prompt, the model composes a new scene.
+  Good for abstract shots, establishing shots, and content where no hero frame exists.
+- **I2V (`wan2.7-i2v`):** starts from an existing still (often a `wan_image` /
+  `qwen_image` / `flux_image` hero) and animates it. Strongly preferred for
+  keeping visual consistency across an explainer where the image stack is
+  already committed to a look.
+
+### Prompt guidance
+
+No official Wan prompt guide exists — use the universal formula in this file.
+Observed behavior on Wan 2.7:
+
+- Responds well to English cinematographic vocabulary (shot size, movement,
+  lens, lighting, style) and to Chinese prompts natively — do not pre-translate.
+- `prompt_extend=true` (default) lets DashScope auto-enrich short prompts; disable
+  when you want strict control over phrasing.
+- For I2V, describe **motion only**. Do not re-describe what is already in the
+  reference image; the model keeps identity and setting from `img_url`.
+- Keep a single scene per clip; cut between shots rather than asking for cuts
+  inside a prompt.
+- Audio is not generated — plan narration and music in the asset stage.
+
+### Example I2V prompt (Wan 2.7)
+
+```
+[Camera]: Slow push-in, handheld micro-jitter
+[Motion]: The beekeeper tilts the frame toward camera, golden honey
+          droplets tremble and release one by one into slow motion
+[Lighting]: Warm late-afternoon light unchanged from reference
+[Style]: Documentary cinematography, 35mm film grain, 24fps
+```
+
+Pair with `img_url` pointing to the hero image generated earlier
+(`wan_image` / `qwen_image` / `flux_image` output, uploaded to a URL the
+DashScope task can fetch).
 
 ## Example: Generic Prompt Template
 

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -29,6 +29,7 @@ from tools.tool_registry import ToolRegistry
 from tools.audio.elevenlabs_tts import ElevenLabsTTS
 from tools.audio.openai_tts import OpenAITTS
 from tools.audio.piper_tts import PiperTTS
+from tools.audio.qwen_tts import QWEN_TTS_MODELS, QWEN_TTS_VOICES, QwenTTS
 from tools.audio.tts_selector import TTSSelector
 
 
@@ -92,6 +93,154 @@ class TestMusicGen:
         assert "generate_background_music" in tool.capabilities
 
 
+class TestQwenTTS:
+    def test_identity(self):
+        tool = QwenTTS()
+        info = tool.get_info()
+        assert info["name"] == "qwen_tts"
+        assert info["tier"] == "voice"
+        assert info["capability"] == "tts"
+        assert info["provider"] == "qwen"
+
+    def test_capabilities(self):
+        tool = QwenTTS()
+        assert "text_to_speech" in tool.capabilities
+        assert "voice_selection" in tool.capabilities
+        assert "chinese_dialects" in tool.capabilities
+
+    def test_cost_scales_with_text_length(self):
+        tool = QwenTTS()
+        short = tool.estimate_cost({"text": "Hi."})
+        long = tool.estimate_cost({"text": "x" * 1000})
+        assert long > short
+        assert short >= 0
+
+    def test_input_schema_voices_match_module(self):
+        tool = QwenTTS()
+        voices = tool.input_schema["properties"]["voice"]["enum"]
+        assert set(voices) == set(QWEN_TTS_VOICES)
+        assert "Cherry" in voices
+
+    def test_models_enumerated(self):
+        tool = QwenTTS()
+        models = tool.input_schema["properties"]["model"]["enum"]
+        assert set(models) == set(QWEN_TTS_MODELS)
+        assert "qwen-tts" in models
+        assert "qwen-tts-latest" in models
+
+    def test_status_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        monkeypatch.delenv("ALIYUN_DASHSCOPE_API_KEY", raising=False)
+        from tools.base_tool import ToolStatus
+        assert QwenTTS().get_status() == ToolStatus.UNAVAILABLE
+
+    def test_execute_without_key_returns_error(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        monkeypatch.delenv("ALIYUN_DASHSCOPE_API_KEY", raising=False)
+        result = QwenTTS().execute({"text": "hello"})
+        assert result.success is False
+        assert "DASHSCOPE_API_KEY" in result.error
+
+    def test_execute_rejects_unknown_model(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
+        result = QwenTTS().execute({"text": "hi", "model": "nope"})
+        assert result.success is False
+        assert "Unknown qwen_tts model" in result.error
+
+    def test_execute_rejects_unknown_voice(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
+        result = QwenTTS().execute({"text": "hi", "voice": "Bogus"})
+        assert result.success is False
+        assert "Unknown qwen_tts voice" in result.error
+
+    def test_dialect_voice_requires_latest_model(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
+        result = QwenTTS().execute({"text": "hi", "voice": "Dylan", "model": "qwen-tts"})
+        assert result.success is False
+        assert "dialect" in result.error.lower()
+
+    def test_extract_audio_url_top_level(self):
+        body = {"output": {"audio": {"url": "https://example.com/a.mp3"}}}
+        assert QwenTTS._extract_audio_url(body) == "https://example.com/a.mp3"
+
+    def test_extract_audio_url_nested_choices(self):
+        body = {
+            "output": {
+                "choices": [
+                    {
+                        "message": {
+                            "content": [
+                                {"audio": {"url": "https://example.com/b.mp3"}}
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        assert QwenTTS._extract_audio_url(body) == "https://example.com/b.mp3"
+
+    def test_extract_audio_url_missing(self):
+        assert QwenTTS._extract_audio_url({"output": {}}) is None
+
+    def test_execute_happy_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
+
+        class FakeResponse:
+            def __init__(self, body):
+                self._body = body
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return self._body
+
+        captured = {}
+
+        def fake_post(url, headers=None, json=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["payload"] = json
+            return FakeResponse({
+                "request_id": "req-1",
+                "output": {"audio": {"url": "https://example.com/audio.mp3"}},
+                "usage": {"audio_tokens": 7},
+            })
+
+        def fake_download(url, output_path, timeout=120):
+            from pathlib import Path
+            p = Path(output_path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"FAKE_AUDIO")
+            return p
+
+        import requests
+        from tools import _dashscope as dashscope_mod
+        monkeypatch.setattr(requests, "post", fake_post)
+        monkeypatch.setattr(dashscope_mod, "download_asset", fake_download)
+
+        out_path = tmp_path / "qwen.mp3"
+        result = QwenTTS().execute({
+            "text": "Hello world",
+            "voice": "Cherry",
+            "model": "qwen-tts-latest",
+            "output_path": str(out_path),
+        })
+
+        assert result.success is True, result.error
+        assert result.data["provider"] == "qwen"
+        assert result.data["model"] == "qwen-tts-latest"
+        assert result.data["voice"] == "Cherry"
+        assert result.data["request_id"] == "req-1"
+        assert result.data["audio_url"] == "https://example.com/audio.mp3"
+        assert result.artifacts == [str(out_path)]
+        assert out_path.read_bytes() == b"FAKE_AUDIO"
+        assert captured["payload"] == {
+            "model": "qwen-tts-latest",
+            "input": {"text": "Hello world", "voice": "Cherry"},
+        }
+        assert captured["headers"]["Authorization"] == "Bearer fake-key"
+        assert "X-DashScope-Async" not in captured["headers"]
+
+
 class TestNewToolsRegistry:
     def test_all_register(self):
         reg = ToolRegistry()
@@ -143,7 +292,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"elevenlabs", "google_tts", "openai", "piper", "qwen"}
 
 
 # ---- Animated Explainer Pipeline ----

--- a/tools/audio/qwen_tts.py
+++ b/tools/audio/qwen_tts.py
@@ -71,7 +71,7 @@ class QwenTTS(BaseTool):
     install_instructions = dashscope.INSTALL_INSTRUCTIONS
     fallback = "openai_tts"
     fallback_tools = ["openai_tts", "elevenlabs_tts", "google_tts", "piper_tts"]
-    agent_skills = ["text-to-speech"]
+    agent_skills = ["dashscope", "text-to-speech"]
 
     capabilities = [
         "text_to_speech",

--- a/tools/audio/qwen_tts.py
+++ b/tools/audio/qwen_tts.py
@@ -1,0 +1,281 @@
+"""Qwen-TTS text-to-speech provider tool via Alibaba DashScope API.
+
+Qwen-TTS is Alibaba's text-to-speech family served through Model Studio
+(Bailian). Voices include neutral English/Chinese personas (Cherry, Ethan,
+Chelsie, Serena) and Chinese dialect personas exposed by the ``-latest``
+model (Dylan/Beijing, Sunny/Sichuan, Jada/Shanghai).
+
+The endpoint returns an audio URL synchronously (no async polling needed):
+
+  POST https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation
+    body: {"model": "qwen-tts", "input": {"text": "...", "voice": "Cherry"}}
+    -> output.audio.url -> download
+
+See: https://help.aliyun.com/zh/model-studio/qwen-tts-api
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from tools import _dashscope as dashscope
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+QWEN_TTS_ENDPOINT = (
+    f"{dashscope.DASHSCOPE_BASE_URL}/services/aigc/multimodal-generation/generation"
+)
+
+QWEN_TTS_MODELS: dict[str, dict[str, Any]] = {
+    "qwen-tts": {"cost_per_1k_chars_usd": 0.0014, "supports_dialects": False},
+    "qwen-tts-latest": {"cost_per_1k_chars_usd": 0.0014, "supports_dialects": True},
+    "qwen-tts-2025-05-22": {"cost_per_1k_chars_usd": 0.0014, "supports_dialects": False},
+}
+
+QWEN_TTS_VOICES = [
+    "Cherry",
+    "Ethan",
+    "Chelsie",
+    "Serena",
+    "Dylan",
+    "Sunny",
+    "Jada",
+]
+
+
+class QwenTTS(BaseTool):
+    name = "qwen_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "qwen"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = dashscope.INSTALL_INSTRUCTIONS
+    fallback = "openai_tts"
+    fallback_tools = ["openai_tts", "elevenlabs_tts", "google_tts", "piper_tts"]
+    agent_skills = ["text-to-speech"]
+
+    capabilities = [
+        "text_to_speech",
+        "voice_selection",
+        "multilingual",
+        "chinese_native",
+        "chinese_dialects",
+    ]
+    supports = {
+        "voice_cloning": False,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "chinese_prompt": True,
+        "chinese_dialects": True,
+    }
+    best_for = [
+        "native Chinese narration via Alibaba Model Studio",
+        "Chinese dialect voiceovers (Beijing, Sichuan, Shanghai)",
+        "bilingual Chinese/English delivery",
+    ]
+    not_good_for = [
+        "voice cloning",
+        "fully offline production",
+    ]
+
+    provider_matrix = {
+        variant: {
+            "tool": "qwen_tts",
+            "mode": "api",
+            "cost_per_1k_chars_usd": meta["cost_per_1k_chars_usd"],
+            "supports_dialects": meta["supports_dialects"],
+        }
+        for variant, meta in QWEN_TTS_MODELS.items()
+    }
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {"type": "string", "description": "Text to convert to speech"},
+            "model": {
+                "type": "string",
+                "enum": sorted(QWEN_TTS_MODELS),
+                "default": "qwen-tts-latest",
+            },
+            "voice": {
+                "type": "string",
+                "enum": QWEN_TTS_VOICES,
+                "default": "Cherry",
+                "description": (
+                    "Voice persona. Cherry/Ethan/Chelsie/Serena are bilingual "
+                    "EN/ZH; Dylan/Sunny/Jada are Chinese dialect voices "
+                    "(qwen-tts-latest only)."
+                ),
+            },
+            "format": {
+                "type": "string",
+                "default": "mp3",
+                "enum": ["mp3", "wav"],
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["text", "voice", "model", "format"]
+    side_effects = ["writes audio file to output_path", "calls Alibaba DashScope API"]
+    user_visible_verification = ["Listen to generated audio for natural speech quality"]
+
+    _DIALECT_VOICES = {"Dylan", "Sunny", "Jada"}
+
+    def get_status(self) -> ToolStatus:
+        if dashscope.get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        text = inputs.get("text", "")
+        model = inputs.get("model", "qwen-tts-latest")
+        meta = QWEN_TTS_MODELS.get(model, QWEN_TTS_MODELS["qwen-tts-latest"])
+        return round(len(text) / 1000.0 * meta["cost_per_1k_chars_usd"], 4)
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = dashscope.get_api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="DASHSCOPE_API_KEY not set. " + self.install_instructions,
+            )
+
+        model = inputs.get("model", "qwen-tts-latest")
+        if model not in QWEN_TTS_MODELS:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"Unknown qwen_tts model {model!r}. "
+                    f"Allowed: {sorted(QWEN_TTS_MODELS)}"
+                ),
+            )
+
+        voice = inputs.get("voice", "Cherry")
+        if voice not in QWEN_TTS_VOICES:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"Unknown qwen_tts voice {voice!r}. "
+                    f"Allowed: {QWEN_TTS_VOICES}"
+                ),
+            )
+        if voice in self._DIALECT_VOICES and not QWEN_TTS_MODELS[model]["supports_dialects"]:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"Voice {voice!r} requires a dialect-capable model "
+                    "(use 'qwen-tts-latest')."
+                ),
+            )
+
+        start = time.time()
+        try:
+            result = self._generate(inputs, api_key, model, voice)
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Qwen TTS failed: {exc}")
+
+        result.duration_seconds = round(time.time() - start, 2)
+        result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def _generate(
+        self,
+        inputs: dict[str, Any],
+        api_key: str,
+        model: str,
+        voice: str,
+    ) -> ToolResult:
+        import requests
+
+        text = inputs["text"]
+        fmt = inputs.get("format", "mp3")
+
+        payload = {
+            "model": model,
+            "input": {"text": text, "voice": voice},
+        }
+
+        response = requests.post(
+            QWEN_TTS_ENDPOINT,
+            headers=dashscope.build_headers(api_key, async_task=False),
+            json=payload,
+            timeout=120,
+        )
+        response.raise_for_status()
+        body = response.json()
+
+        audio_url = self._extract_audio_url(body)
+        if not audio_url:
+            raise RuntimeError(f"Qwen TTS response missing audio URL: {body!r}")
+
+        output_path = Path(inputs.get("output_path", f"qwen_tts.{fmt}"))
+        dashscope.download_asset(audio_url, output_path)
+
+        request_id = body.get("request_id")
+        usage = body.get("usage") or {}
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model,
+                "voice": voice,
+                "format": fmt,
+                "text_length": len(text),
+                "output": str(output_path),
+                "audio_url": audio_url,
+                "request_id": request_id,
+                "usage": usage,
+            },
+            artifacts=[str(output_path)],
+            model=f"dashscope/{model}",
+        )
+
+    @staticmethod
+    def _extract_audio_url(body: dict[str, Any]) -> str | None:
+        """Pull the audio URL out of a Qwen-TTS response.
+
+        DashScope multimodal-generation responses place the result under
+        ``output.audio.url``; some variants nest it inside
+        ``output.choices[0].message.content[*].audio.url``.
+        """
+        output = body.get("output") or {}
+        audio = output.get("audio")
+        if isinstance(audio, dict) and isinstance(audio.get("url"), str):
+            return audio["url"]
+        for choice in output.get("choices") or []:
+            message = choice.get("message") if isinstance(choice, dict) else None
+            content = message.get("content") if isinstance(message, dict) else None
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict):
+                        nested = part.get("audio")
+                        if isinstance(nested, dict) and isinstance(nested.get("url"), str):
+                            return nested["url"]
+        return None

--- a/tools/graphics/qwen_image.py
+++ b/tools/graphics/qwen_image.py
@@ -63,7 +63,7 @@ class QwenImage(BaseTool):
 
     dependencies = []  # checked dynamically via env var
     install_instructions = dashscope.INSTALL_INSTRUCTIONS
-    agent_skills = []
+    agent_skills = ["dashscope"]
 
     capabilities = [
         "generate_image",

--- a/tools/graphics/wan_image.py
+++ b/tools/graphics/wan_image.py
@@ -64,7 +64,7 @@ class WanImage(BaseTool):
 
     dependencies = []  # checked dynamically via env var
     install_instructions = dashscope.INSTALL_INSTRUCTIONS
-    agent_skills = []
+    agent_skills = ["dashscope"]
 
     capabilities = [
         "generate_image",

--- a/tools/video/wan_video_api.py
+++ b/tools/video/wan_video_api.py
@@ -67,7 +67,7 @@ class WanVideoApi(BaseTool):
 
     dependencies = []  # checked dynamically via env var
     install_instructions = dashscope.INSTALL_INSTRUCTIONS
-    agent_skills = ["ai-video-gen"]
+    agent_skills = ["dashscope", "ai-video-gen"]
 
     capabilities = [
         "text_to_video",


### PR DESCRIPTION
## Summary

Closes [#4](https://github.com/davideuler/openmontage/issues/4) by integrating `qwen-tts` as a TTS provider **and** extending documentation coverage for the full Alibaba DashScope (Wan + Qwen) generation stack across every skill layer.

### Code

- New `tools/audio/qwen_tts.py` (`provider="qwen"`, `capability="tts"`).
  Supports `qwen-tts`, `qwen-tts-latest`, `qwen-tts-2025-05-22` models; bilingual EN/ZH voices (Cherry, Ethan, Chelsie, Serena) and Chinese dialect voices (Dylan/Beijing, Sunny/Sichuan, Jada/Shanghai). Dialect voices are gated to `qwen-tts-latest`. Synchronous POST — reads `output.audio.url` and downloads via the shared `_dashscope` helpers.
- Auto-discovered by `TTSSelector` via the registry — no selector changes needed.
- `agent_skills` wired up across the DashScope tools so the registry surfaces the new Layer 3 skill:
  - `qwen_tts` → `["dashscope", "text-to-speech"]`
  - `qwen_image` → `["dashscope"]`
  - `wan_image` → `["dashscope"]`
  - `wan_video_api` → `["dashscope", "ai-video-gen"]`

### Skill documentation

**Layer 3** (`.agents/skills/` + `.claude/skills/`):
- New `dashscope/SKILL.md` in both directories. Covers auth (`DASHSCOPE_API_KEY`, `ALIYUN_DASHSCOPE_API_KEY` alias), the async task pattern shared by images + videos, the synchronous TTS pattern, model tiers/sizes/limits, prompt guidance, and common pitfalls. Points agents at `tools/_dashscope.py` helpers instead of reimplementing HTTP plumbing.
- `ai-video-gen/SKILL.md` gateway matrix gains a DashScope row and links out to the new skill.

**Layer 2** (`skills/creative/`):
- New `tts-provider-usage.md` — selection matrix across ElevenLabs / OpenAI / Google / Qwen / Piper, per-provider notes, Alibaba Model Studio production path, loudness-drift warnings, dialect gating.
- `image-provider-usage.md` — landscape table, scene-type selector, cost-quality production path, and caveats for `qwen_image` and `wan_image`.
- `video-gen-prompting.md` — adds Wan 2.7 / 2.6 / 2.5 (DashScope) to the model guide, updates the "when to use" list to include `wan_video_api`, and appends a dedicated section covering T2V vs I2V decision logic, model tiers, supported sizes, and an I2V prompt example.
- `skills/INDEX.md` — references the new TTS Provider Usage skill, threads `dashscope` through the Layer 3 columns, and adds a DashScope row to the installed-skills table.

## Test plan

- [x] `pytest tests/contracts/test_phase3_contracts.py` — 77 passed.
- [x] New `TestQwenTTS` class covers identity / capability / provider fields, cost scaling, schema-enum matches, missing-API-key error path, unknown model and unknown voice rejection, dialect-voice gating to `qwen-tts-latest`, `_extract_audio_url` for both top-level and nested `choices[].message.content[].audio.url` response shapes, and a full happy-path that monkeypatches `requests.post` + `_dashscope.download_asset` to assert payload, auth header, artifact path, and returned metadata.
- [x] `TestCapabilityMetadata::test_registry_catalog_views` updated to expect the new `qwen` provider in `registry.capability_catalog()["tts"]`.
- [x] Verified via the registry: `registry.get_by_capability("tts")` includes `qwen_tts`; `get_info()["agent_skills"]` surfaces `dashscope` for the four DashScope tools.
- [x] Pre-existing failures in `tests/tools/test_dashscope_providers.py::TestHappyPaths` are unrelated to this change (reproduced on the baseline branch without these commits).

https://claude.ai/code/session_01N7s8rfBgezUgKatbmLPRYw